### PR TITLE
Formatting a file in place (#14)

### DIFF
--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -9,7 +9,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 
 data Config = Config
-    { _file :: FilePath
+    { _input :: FilePath
     , _output :: FilePath
     }
 
@@ -33,7 +33,7 @@ parse =
 flags :: Opt.Parser Config
 flags =
     Config
-      <$> file
+      <$> input
       <*> output
 
 
@@ -94,6 +94,6 @@ output =
         , Opt.help "Write output to OUTPUT instead of overwriting the given source file."
         ]
 
-file :: Opt.Parser FilePath
-file =
+input :: Opt.Parser FilePath
+input =
     Opt.strArgument $ Opt.metavar "INPUT"

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -35,9 +35,6 @@ flags =
     Config
       <$> file
       <*> output
-  where
-    file =
-      Opt.strArgument $ Opt.metavar "FILE"
 
 
 -- HELP
@@ -92,6 +89,11 @@ output =
     Opt.strOption $
         mconcat
         [ Opt.long "output"
-        , Opt.metavar "FILE"
-        , Opt.help "Write output to FILE instead of overwriting the given source file."
+        , Opt.metavar "OUTPUT"
+        , Opt.value ""
+        , Opt.help "Write output to OUTPUT instead of overwriting the given source file."
         ]
+
+file :: Opt.Parser FilePath
+file =
+    Opt.strArgument $ Opt.metavar "INPUT"

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -10,7 +10,7 @@ import qualified Text.PrettyPrint.ANSI.Leijen as PP
 
 data Config = Config
     { _input :: FilePath
-    , _output :: FilePath
+    , _output :: Maybe FilePath
     }
 
 -- PARSE ARGUMENTS
@@ -84,13 +84,12 @@ dependencies =
         ]
 
 
-output :: Opt.Parser FilePath
+output :: Opt.Parser (Maybe FilePath)
 output =
-    Opt.strOption $
+    Opt.optional $ Opt.strOption $
         mconcat
         [ Opt.long "output"
         , Opt.metavar "OUTPUT"
-        , Opt.value ""
         , Opt.help "Write output to OUTPUT instead of overwriting the given source file."
         ]
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,6 +4,7 @@ module Main where
 import Elm.Utils ((|>))
 import System.Exit (exitFailure)
 import Control.Monad (when)
+import Data.Maybe (isJust, fromMaybe)
 
 import qualified AST.Module
 import qualified Box
@@ -32,19 +33,18 @@ formatResult config result =
                 |> LazyText.writeFile outputFile
         Result.Result _ (Result.Err errs) ->
             do
-                when (not isOutputEmpty)
-                  (LazyText.writeFile (Flags._output config)
-                    $ LazyText.pack "")
+                case givenOutput of
+                  Just givenOutputFile ->
+                    LazyText.writeFile givenOutputFile $ LazyText.pack ""
 
                 putStrLn "ERRORS"
                 _ <- sequence $ map printError errs
                 exitFailure
     where
         trimSpaces = LazyText.unlines . (map LazyText.stripEnd) . LazyText.lines
-        isOutputEmpty = null (Flags._output config)
-        outputFile = if isOutputEmpty
-                         then Flags._input config
-                         else Flags._output config
+        givenInput = Flags._input config
+        givenOutput = Flags._output config
+        outputFile = fromMaybe givenInput givenOutput
 
 
 printError :: RA.Located Syntax.Error -> IO ()

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -43,7 +43,7 @@ formatResult config result =
         trimSpaces = LazyText.unlines . (map LazyText.stripEnd) . LazyText.lines
         isOutputEmpty = null (Flags._output config)
         outputFile = if isOutputEmpty
-                         then Flags._file config
+                         then Flags._input config
                          else Flags._output config
 
 
@@ -56,6 +56,6 @@ main :: IO ()
 main =
     do  config <- Flags.parse
 
-        input <- LazyText.readFile (Flags._file config)
+        input <- LazyText.readFile (Flags._input config)
 
         formatResult config $ Parse.parseSource $ LazyText.unpack input

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -7,6 +7,51 @@ else
 	MD5="md5sum"
 fi
 
+function returnCodeShouldEqual() {
+  [ "$?" -eq "$1" ] || exit 1
+}
+
+function shouldOutputTheSame() {
+  diff <(echo "$1") <(echo "$2") || exit 1
+}
+
+function checkWaysToRun() {
+	INPUT="tests/test-files/good/$1"
+	OUTPUT="formatted.elm"
+
+	echo
+	echo "## elm-format --help"
+  HELP=`"$ELM_FORMAT" --help 2>&1`
+  returnCodeShouldEqual 0
+  echo "OK"
+
+	echo
+	echo "## elm-format -h"
+  SHORTHELP=`"$ELM_FORMAT" -h 2>&1`
+  returnCodeShouldEqual 0
+  shouldOutputTheSame "$HELP" "$SHORTHELP"
+  echo "OK"
+
+	echo
+	echo "## elm-format"
+  NOARGS=`"$ELM_FORMAT" 2>&1`
+  returnCodeShouldEqual 1
+  shouldOutputTheSame "$HELP" "$NOARGS"
+  echo "OK"
+
+	echo
+	echo "## elm-format INPUT"
+	"$ELM_FORMAT" "$INPUT"
+  returnCodeShouldEqual 0
+  echo "OK"
+
+	echo
+	echo "## elm-format INPUT --output OUTPUT"
+	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT"
+  returnCodeShouldEqual 0
+  echo "OK"
+}
+
 function checkGood() {
 	INPUT="tests/test-files/good/$1"
 	OUTPUT="formatted.elm"
@@ -33,6 +78,8 @@ function checkTransformation() {
 echo
 echo
 echo "# elm-format test suite"
+
+checkWaysToRun Simple.elm
 
 checkGood Simple.elm
 checkGood AllSyntax.elm

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -8,11 +8,11 @@ else
 fi
 
 function returnCodeShouldEqual() {
-  [ "$?" -eq "$1" ] || exit 1
+	[ "$?" -eq "$1" ] || exit 1
 }
 
 function shouldOutputTheSame() {
-  diff <(echo "$1") <(echo "$2") || exit 1
+	diff <(echo "$1") <(echo "$2") || exit 1
 }
 
 function checkWaysToRun() {
@@ -21,35 +21,35 @@ function checkWaysToRun() {
 
 	echo
 	echo "## elm-format --help"
-  HELP=`"$ELM_FORMAT" --help 2>&1`
-  returnCodeShouldEqual 0
-  echo "OK"
+	HELP=`"$ELM_FORMAT" --help 2>&1`
+	returnCodeShouldEqual 0
+	echo "OK"
 
 	echo
 	echo "## elm-format -h"
-  SHORTHELP=`"$ELM_FORMAT" -h 2>&1`
-  returnCodeShouldEqual 0
-  shouldOutputTheSame "$HELP" "$SHORTHELP"
-  echo "OK"
+	SHORTHELP=`"$ELM_FORMAT" -h 2>&1`
+	returnCodeShouldEqual 0
+	shouldOutputTheSame "$HELP" "$SHORTHELP"
+	echo "OK"
 
 	echo
 	echo "## elm-format"
-  NOARGS=`"$ELM_FORMAT" 2>&1`
-  returnCodeShouldEqual 1
-  shouldOutputTheSame "$HELP" "$NOARGS"
-  echo "OK"
+	NOARGS=`"$ELM_FORMAT" 2>&1`
+	returnCodeShouldEqual 1
+	shouldOutputTheSame "$HELP" "$NOARGS"
+	echo "OK"
 
 	echo
 	echo "## elm-format INPUT"
 	"$ELM_FORMAT" "$INPUT"
-  returnCodeShouldEqual 0
-  echo "OK"
+	returnCodeShouldEqual 0
+	echo "OK"
 
 	echo
 	echo "## elm-format INPUT --output OUTPUT"
 	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT"
-  returnCodeShouldEqual 0
-  echo "OK"
+	returnCodeShouldEqual 0
+	echo "OK"
 }
 
 function checkGood() {


### PR DESCRIPTION
I have not done Haskell in a long time, so there are probably some code style changes you'll want me to do. (I'm particularly unsure about the `when` ... and maybe the definition of `isOutputEmpty` could use a `$`?

And it would probably make more sense for the `output` option to be `Maybe FilePath` instead of a `FilePath` that can be `""` ... if you want me to refactor it that way, I can try.

Otherwise the functionality is as promised:
```bash
./elm-format MyFile.elm # formats it in place, but doesn't empty it if there's a parse error
./elm-format MyFile.elm --output MyFile2.elm # creates MyFile2.elm, writes the result if successful or leaves empty if parse error
```

(No interactive warning yet.)