### PR TITLE
Format directories

### DIFF
--- a/elm-format.cabal
+++ b/elm-format.cabal
@@ -52,6 +52,7 @@ Executable elm-format
         directory >= 1.0 && < 2.0,
         edit-distance >= 0.2 && < 0.3,
         filepath >= 1 && < 2.0,
+        filemanip >= 0.1 && < 1.0,
         indents >= 0.3 && < 0.4,
         language-glsl >= 0.0.2 && < 0.3,
         mtl >= 2.2 && < 3,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,6 +18,7 @@ import qualified Reporting.Annotation as RA
 import qualified Reporting.Error.Syntax as Syntax
 import qualified Reporting.Report as Report
 import qualified Reporting.Result as Result
+import qualified System.Directory as Dir
 
 
 showErrors :: [RA.Located Syntax.Error] -> IO ()
@@ -71,6 +72,12 @@ getApproval autoYes filePath =
             putStr "Are you sure you want to overwrite these files with formatted versions? (y/n) "
             Cmd.yesOrNo
 
+printFileNotFound :: FilePath -> IO ()
+printFileNotFound filePath = do
+    putStrLn "Could not find the file:\n"
+    putStrLn $ "  " ++ filePath ++ "\n"
+    putStrLn "Please check the given path."
+
 processFile :: FilePath -> FilePath -> IO ()
 processFile inputFile outputFile =
     do
@@ -88,6 +95,12 @@ main =
         let inputFile = (Flags._input config)
         let outputFile = (Flags._output config)
         let autoYes = (Flags._yes config)
+
+        fileExists <- Dir.doesFileExist inputFile
+
+        when (not fileExists) $ do
+            printFileNotFound inputFile
+            exitFailure
 
         case outputFile of
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -76,14 +76,18 @@ main :: IO ()
 main =
     do  config <- Flags.parse
 
-        case (Flags._output config) of
+        case outputFile of
             Nothing -> do -- we are overwriting the input file
-                canOverwrite <- getApproval (Flags._yes config) (Flags._input config)
+                canOverwrite <- getApproval autoYes inputFile
                 case canOverwrite of
                     True -> return ()
                     False -> exitSuccess
             Just _ -> return ()
 
-        input <- LazyText.readFile (Flags._input config)
+        input <- LazyText.readFile inputFile
 
         formatResult config $ Parse.parseSource $ LazyText.unpack input
+    where
+        inputFile = (Flags._input config)
+        outputFile = (Flags._output config)
+        autoYes = (Flags._yes config)

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -28,6 +28,10 @@ function compareFiles() {
 function checkWaysToRun() {
 	INPUT="tests/test-files/good/$1"
 	OUTPUT="formatted.elm"
+
+  NONEXISTENT_AT_TMP=`tempfile`
+  NONEXISTENT=`basename "$NONEXISTENT_AT_TMP"`
+
 	echo
 
 	echo "## elm-format --help"
@@ -59,6 +63,10 @@ function checkWaysToRun() {
 	echo "## elm-format --yes INPUT"
 	"$ELM_FORMAT" --yes "$INPUT"
 	returnCodeShouldEqual 0
+
+	echo "## elm-format NONEXISTENT --yes"
+	"$ELM_FORMAT" "$NONEXISTENT" --yes 1>/dev/null
+	returnCodeShouldEqual 1
 
 	echo "## elm-format INPUT --output OUTPUT"
 	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -33,6 +33,7 @@ function checkWaysToRun() {
 
   NONEXISTENT_AT_TMP=`tempfile`
   NONEXISTENT=`basename "$NONEXISTENT_AT_TMP"`
+  NONEXISTENT_DIR=`mktemp -d`
 
 	echo
   echo "------------------------------"
@@ -95,6 +96,10 @@ function checkWaysToRun() {
 
   echo "## elm-format DIRECTORY --yes"
 	"$ELM_FORMAT" "$DIRECTORY" --yes 1>/dev/null 2>/dev/null
+	returnCodeShouldEqual 1
+
+  echo "## elm-format NONEXISTENT_DIRECTORY --yes"
+	"$ELM_FORMAT" "$NONEXISTENT_DIR" --yes 1>/dev/null
 	returnCodeShouldEqual 1
 
 	echo "# OK!"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -28,11 +28,16 @@ function compareFiles() {
 function checkWaysToRun() {
 	INPUT="tests/test-files/good/$1"
 	OUTPUT="formatted.elm"
+	DIRECTORY="tests/test-files/directory"
+	RECURSIVE_DIRECTORY="tests/test-files/recursive-directory"
 
   NONEXISTENT_AT_TMP=`tempfile`
   NONEXISTENT=`basename "$NONEXISTENT_AT_TMP"`
 
 	echo
+  echo "------------------------------"
+  echo "# WAYS TO RUN"
+  echo
 
 	echo "## elm-format --help"
 	HELP=`"$ELM_FORMAT" --help 2>&1`
@@ -57,11 +62,11 @@ function checkWaysToRun() {
 	returnCodeShouldEqual 0
 
 	echo "## elm-format INPUT --yes"
-	"$ELM_FORMAT" "$INPUT" --yes
+	"$ELM_FORMAT" "$INPUT" --yes 1>/dev/null
 	returnCodeShouldEqual 0
 
 	echo "## elm-format --yes INPUT"
-	"$ELM_FORMAT" --yes "$INPUT"
+	"$ELM_FORMAT" --yes "$INPUT" 1>/dev/null
 	returnCodeShouldEqual 0
 
 	echo "## elm-format NONEXISTENT --yes"
@@ -69,12 +74,31 @@ function checkWaysToRun() {
 	returnCodeShouldEqual 1
 
 	echo "## elm-format INPUT --output OUTPUT"
-	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT"
+	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT" 1>/dev/null
 	returnCodeShouldEqual 0
-	compareFiles "$INPUT" "$OUTPUT"
+	compareFiles "$INPUT" "$OUTPUT" 1>/dev/null
 
-	echo
-	echo "# CLI tests OK!"
+  echo "## elm-format DIRECTORY --output OUTPUT"
+	"$ELM_FORMAT" "$DIRECTORY" --output "$OUTPUT" 1>/dev/null
+	returnCodeShouldEqual 1
+
+  echo "## elm-format DIRECTORY (answer = n)"
+	echo "n" | "$ELM_FORMAT" "$DIRECTORY" 1>/dev/null
+	returnCodeShouldEqual 0
+
+  echo "## elm-format DIRECTORY (answer = y)"
+	echo "y" | "$ELM_FORMAT" "$RECURSIVE_DIRECTORY" 1>/dev/null 2>/dev/null
+	returnCodeShouldEqual 1
+  # invalid file in the nested directory
+  # if recursion didn't work, return code would be 0
+  # because it never got to the nested invalid file
+
+  echo "## elm-format DIRECTORY --yes"
+	"$ELM_FORMAT" "$DIRECTORY" --yes 1>/dev/null 2>/dev/null
+	returnCodeShouldEqual 1
+
+	echo "# OK!"
+  echo "------------------------------"
 }
 
 function checkGood() {
@@ -83,7 +107,7 @@ function checkGood() {
 
 	echo
 	echo "## good/$1"
-	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT"
+	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT" 1>/dev/null
 	returnCodeShouldEqual 0
 	compareFiles "$INPUT" "$OUTPUT"
 }
@@ -95,7 +119,7 @@ function checkTransformation() {
 
 	echo
 	echo "## transform/$1"
-	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT"
+	"$ELM_FORMAT" "$INPUT" --output "$OUTPUT" 1>/dev/null
 	returnCodeShouldEqual 0
 	compareFiles "$EXPECTED" "$OUTPUT"
 }

--- a/tests/test-files/directory/invalid.elm
+++ b/tests/test-files/directory/invalid.elm
@@ -1,0 +1,4 @@
+module Main (..) where
+
+x ad,dress =
+    button [ onClick address (AddStatus { id = 50 }) ] [ text "add status" ]

--- a/tests/test-files/directory/valid.elm
+++ b/tests/test-files/directory/valid.elm
@@ -1,0 +1,4 @@
+module X (..) where
+
+a =
+    123

--- a/tests/test-files/recursive-directory/nested/invalid.elm
+++ b/tests/test-files/recursive-directory/nested/invalid.elm
@@ -1,0 +1,3 @@
+module X where
+
+ab,c = 123 + x

--- a/tests/test-files/recursive-directory/valid.elm
+++ b/tests/test-files/recursive-directory/valid.elm
@@ -1,0 +1,4 @@
+module X (..) where
+
+abc x =
+    123 + x


### PR DESCRIPTION
Relates to issue #16 (hopefully closes it).

The functional changes:
- we check for existence of the INPUT file/directory and exit appropriately
- we check for existence of any .elm files in the INPUT directory and exit appropriately
- we search the directory recursively for .elm files and always overwrite them in place (asking beforehand), exiting on any failure during the formatting.
- because of no indicator of which file did an error happen in, we write something along the lines of "Processing file xyz.elm" before we start working on that file.

The questions are:

1. (#42) should we always try to format as many files as possible or should we exit on the first failure?
2. (#43) should we allow for usage `elm-format DIR --output DIR2`, copying the filenames one for one there?
3. should I try to somehow inject the file-with-error path into the now useless "<location>" placeholder inside the error report, or is it good as it is ("Processing file xyz.elm")? This seems like a nontrivial task, modifying the parser to allow for an extra argument etc.

The code probably needs some refactoring (at least extracting the error messages into a different module?) but I need a bit of a break from it so that I can see it "with a new set of eyes" :) Suggestions welcome! (And some Haskell style.)