### PR TITLE
Read from stdin

### DIFF
--- a/src/CommandLine/Helpers.hs
+++ b/src/CommandLine/Helpers.hs
@@ -1,6 +1,17 @@
 module CommandLine.Helpers where
 
 import System.IO
+import System.Exit (exitFailure, exitSuccess)
+import Messages.Types (Message(..))
+import Messages.Strings (renderMessage)
+
+import qualified Reporting.Annotation as RA
+import qualified Reporting.Report as Report
+import qualified Reporting.Error.Syntax as Syntax
+
+
+r :: Message -> String
+r = renderMessage
 
 yesOrNo :: IO Bool
 yesOrNo =
@@ -11,3 +22,48 @@ yesOrNo =
         "n" -> return False
         _   -> do putStr "Must type 'y' for yes or 'n' for no: "
                   yesOrNo
+
+
+decideOutputFile :: Bool -> FilePath -> Maybe FilePath -> IO FilePath
+decideOutputFile autoYes inputFile outputFile =
+    case outputFile of
+        Nothing -> do -- we are overwriting the input file
+            canOverwrite <- getApproval autoYes [inputFile]
+            case canOverwrite of
+                True -> return inputFile
+                False -> exitSuccess
+        Just outputFile' -> return outputFile'
+
+
+getApproval :: Bool -> [FilePath] -> IO Bool
+getApproval autoYes filePaths =
+    case autoYes of
+        True ->
+            return True
+        False -> do
+            putStrLn $ (r $ FilesWillBeOverwritten filePaths)
+            yesOrNo
+
+
+exitFilesNotFound :: [FilePath] -> IO ()
+exitFilesNotFound filePaths = do
+    putStrLn $ (r $ NoElmFilesFound filePaths)
+    exitFailure
+
+
+exitOnInputDirAndOutput :: IO ()
+exitOnInputDirAndOutput = do
+    putStrLn $ r CantWriteToOutputBecauseInputIsDirectory
+    exitFailure
+
+
+showErrors :: [RA.Located Syntax.Error] -> IO ()
+showErrors errs = do
+    putStrLn (r ErrorsHeading)
+    mapM_ printError errs
+
+
+printError :: RA.Located Syntax.Error -> IO ()
+printError (RA.A range err) =
+    Report.printError (r ErrorFileLocation) range (Syntax.toReport err) ""
+

--- a/src/CommandLine/Helpers.hs
+++ b/src/CommandLine/Helpers.hs
@@ -51,6 +51,12 @@ exitFilesNotFound filePaths = do
     exitFailure
 
 
+exitTooManyInputSources :: IO ()
+exitTooManyInputSources = do
+    putStrLn $ (r $ TooManyInputSources)
+    exitFailure
+
+
 exitOnInputDirAndOutput :: IO ()
 exitOnInputDirAndOutput = do
     putStrLn $ r CantWriteToOutputBecauseInputIsDirectory

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -79,7 +79,7 @@ someInput
     :: Opt.Mod Opt.ArgumentFields FilePath
     -> Opt.Mod Opt.FlagFields Bool
     -> Opt.Parser (Maybe [FilePath])
-someInput flags others =
+someInput argumentFields flagFields =
     Just <$> Opt.some argInput <|> stdinSwitch
         where
             -- if there's a switch value of true, then
@@ -87,11 +87,11 @@ someInput flags others =
             -- otherwise Nothing
             stdinSwitch :: Opt.Parser (Maybe [FilePath])
             stdinSwitch =
-                switchToMaybe <$> Opt.switch others
+                switchToMaybe <$> Opt.switch flagFields
 
             argInput :: Opt.Parser FilePath
             argInput =
-                Opt.strArgument flags
+                Opt.strArgument argumentFields
 
             switchToMaybe xs =
                 case xs of

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -28,12 +28,13 @@ writeFile' :: FilePath -> Text.Text -> IO ()
 writeFile' filename contents =
     ByteString.writeFile filename $ Text.encodeUtf8 contents
 
-
-formatResult
+-- If elm-format was successful, writes the results to the output
+-- file. Otherwise, display errors and exit
+writeResult
     :: FilePath
     -> Result.Result () Syntax.Error AST.Module.Module
     -> IO ()
-formatResult outputFile result =
+writeResult outputFile result =
     case result of
         Result.Result _ (Result.Ok modu) ->
             Render.render modu
@@ -50,7 +51,7 @@ processFile inputFile outputFile =
         putStrLn $ (r $ ProcessingFile inputFile)
         input <- fmap Text.decodeUtf8 $ ByteString.readFile inputFile
         Parse.parse input
-            |> formatResult outputFile
+            |> writeResult outputFile
 
 
 isEitherFileOrDirectory :: FilePath -> IO Bool
@@ -82,7 +83,7 @@ handleStdinInput outputFile = do
                         Char8.putStrLn rendered
 
                     Just path -> do
-                        formatResult path parsedText
+                        writeResult path parsedText
 
         Result.Result _ (Result.Err errs) ->
             do

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -4,7 +4,7 @@ module Main where
 import Elm.Utils ((|>))
 import System.Exit (exitFailure, exitSuccess)
 import Control.Monad (when)
-import Data.Maybe (isJust)
+import Data.Maybe (isJust, fromJust)
 import Messages.Types (Message(..))
 import Messages.Strings (renderMessage)
 
@@ -12,11 +12,13 @@ import qualified AST.Module
 import qualified CommandLine.Helpers as Cmd
 import qualified Flags
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified ElmFormat.Parse as Parse
 import qualified ElmFormat.Render.Text as Render
 import qualified ElmFormat.Filesystem as FS
+import qualified Options.Applicative as Opt
 import qualified Reporting.Annotation as RA
 import qualified Reporting.Error.Syntax as Syntax
 import qualified Reporting.Report as Report
@@ -100,19 +102,63 @@ decideOutputFile autoYes inputFile outputFile =
                 False -> exitSuccess
         Just outputFile' -> return outputFile'
 
+
 isEitherFileOrDirectory :: FilePath -> IO Bool
 isEitherFileOrDirectory path = do
     fileExists <- Dir.doesFileExist path
     dirExists <- Dir.doesDirectoryExist path
     return $ fileExists || dirExists
 
+-- read input from stdin
+-- if given an output file, then write there
+-- otherwise, stdout
+handleStdinInput :: Maybe FilePath -> IO ()
+handleStdinInput outputFile = do
+    input <- Lazy.getContents
+
+    let parsedText = Parse.parse $ Text.decodeUtf8 $ Lazy.toStrict input
+
+    case parsedText of
+        Result.Result _ (Result.Ok modu) ->
+            do
+                let rendered = Render.render modu |> Text.encodeUtf8
+
+                case outputFile of
+                    Nothing ->
+                        ByteString.putStrLn rendered
+
+                    Just path -> do
+                        formatResult path parsedText
+
+        Result.Result _ (Result.Err errs) ->
+            do
+                showErrors errs
+                exitFailure
+
+isStdinInput :: FilePath -> Bool
+isStdinInput path =
+    path == "-"
+
 main :: IO ()
 main =
     do
         config <- Flags.parse
-        let inputFiles = (Flags._input config)
+        let maybeInputFiles = (Flags._input config)
         let outputFile = (Flags._output config)
         let autoYes = (Flags._yes config)
+
+        -- when we don't have any input, stdin or otherwise
+        when (not $ isJust maybeInputFiles) $ do
+            Flags.showHelpText
+            exitFailure
+
+        let inputFiles = fromJust maybeInputFiles
+        let isStdin = length inputFiles == 1 && (isStdinInput $ head inputFiles)
+
+        -- when we have just one file and it's stdin, handle it then exit
+        when (isStdin) $ do
+            handleStdinInput outputFile
+            exitSuccess
 
         filesExist <-
             all (id) <$> mapM isEitherFileOrDirectory inputFiles

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,13 +12,13 @@ import qualified AST.Module
 import qualified CommandLine.Helpers as Cmd
 import qualified Flags
 import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Char8 as Char8
 import qualified Data.ByteString.Lazy as Lazy
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified ElmFormat.Parse as Parse
 import qualified ElmFormat.Render.Text as Render
 import qualified ElmFormat.Filesystem as FS
-import qualified Options.Applicative as Opt
 import qualified Reporting.Annotation as RA
 import qualified Reporting.Error.Syntax as Syntax
 import qualified Reporting.Report as Report
@@ -125,7 +125,7 @@ handleStdinInput outputFile = do
 
                 case outputFile of
                     Nothing ->
-                        ByteString.putStrLn rendered
+                        Char8.putStrLn rendered
 
                     Just path -> do
                         formatResult path parsedText

--- a/src/Messages/Strings.hs
+++ b/src/Messages/Strings.hs
@@ -40,3 +40,6 @@ renderMessage CantWriteToOutputBecauseInputIsDirectory =
 
 renderMessage (ProcessingFile file) =
     "Processing file " ++ file
+
+renderMessage TooManyInputSources =
+    "Too many input sources! Please only provide one of either INPUT or --stdin"

--- a/src/Messages/Types.hs
+++ b/src/Messages/Types.hs
@@ -10,5 +10,6 @@ data Message
 
   | FilesWillBeOverwritten [FilePath]
   | NoElmFilesFound [FilePath]
+  | TooManyInputSources
   | CantWriteToOutputBecauseInputIsDirectory
   | ProcessingFile FilePath

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -54,7 +54,7 @@ function checkWaysToRun() {
 
 	echo "## elm-format"
 	NOARGS=$("$ELM_FORMAT" 2>&1)
-	returnCodeShouldEqual 1
+	returnCodeShouldEqual 0
 	shouldOutputTheSame "$HELP" "$NOARGS"
 
 	echo "## elm-format INPUT (answer = y)"

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -84,14 +84,21 @@ function checkWaysToRun() {
 
 	echo "## cat INPUT | elm-format --stdin"
 	STDOUT=$(cat "$INPUT" | "$ELM_FORMAT" --stdin 2>&1)
-	echo $STDOUT
 	returnCodeShouldEqual 0
-	cat "$INPUT" | shouldOutputTheSame "$STDOUT"
+	cat "$INPUT" | shouldOutputTheSame "$STDOUT" 1>/dev/null
+
+	echo "## cat INPUT | elm-format --stdin INPUT"
+	STDOUT=$(cat "$INPUT" | "$ELM_FORMAT" --stdin "$INPUT" 2>&1)
+	returnCodeShouldEqual 1
 
 	echo "## cat INPUT | elm-format --stdin --output OUTPUT"
 	cat "$INPUT" | "$ELM_FORMAT" --stdin --output "$OUTPUT" 1>/dev/null
 	returnCodeShouldEqual 0
 	compareFiles "$INPUT" "$OUTPUT" 1>/dev/null
+
+	echo "## cat INPUT | elm-format INPUT --stdin --output OUTPUT"
+	cat "$INPUT" | "$ELM_FORMAT" "$INPUT" --stdin --output "$OUTPUT" 1>/dev/null
+	returnCodeShouldEqual 1
 
 	echo "## elm-format DIRECTORY --output OUTPUT"
 	"$ELM_FORMAT" "$DIRECTORY" --output "$OUTPUT" 1>/dev/null

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -82,6 +82,17 @@ function checkWaysToRun() {
 	returnCodeShouldEqual 0
 	compareFiles "$INPUT" "$OUTPUT" 1>/dev/null
 
+	echo "## cat INPUT | elm-format --stdin"
+	STDOUT=$(cat "$INPUT" | "$ELM_FORMAT" --stdin 2>&1)
+	echo $STDOUT
+	returnCodeShouldEqual 0
+	cat "$INPUT" | shouldOutputTheSame "$STDOUT"
+
+	echo "## cat INPUT | elm-format --stdin --output OUTPUT"
+	cat "$INPUT" | "$ELM_FORMAT" --stdin --output "$OUTPUT" 1>/dev/null
+	returnCodeShouldEqual 0
+	compareFiles "$INPUT" "$OUTPUT" 1>/dev/null
+
 	echo "## elm-format DIRECTORY --output OUTPUT"
 	"$ELM_FORMAT" "$DIRECTORY" --output "$OUTPUT" 1>/dev/null
 	returnCodeShouldEqual 1


### PR DESCRIPTION
Outfoxes https://github.com/avh4/elm-format/issues/66 

I also changed the spec slightly -

- If `elm-format -` run, then read from stdin 
- If `elm-format --stdin` run, then read from stdin
- If `--output` is set, then save to that output file

Ideally, I think I'd like it so that there was only a `--stdin` since it's possible to accidentally do `-` and be trapped in a stdin reader. I added the `--stdin` option, so that it self documents the ability to automatically it print it out when the file is run with no args or `--help` is set.

The only thing I haven't done is update the docs as part of this PR - I wanted to check with @avh4 whether we want to keep `elm-format -` as a thing or to ditch it first.
