### PR TITLE
Mention Emacs under integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ Use the [Elm Language Support](https://packagecontrol.io/packages/Elm%20Language
 1. Run the “Elm Language Support: Run elm-format” command from the Command Palette to run elm-format on the current file
 1. To enable automatic formatting on every save, Go to Preferences -> Package Settings -> Elm Language Support -> User and add this setting: `"elm_format_on_save": true`
 
+#### Integration with Emacs
+
+Use [elm-mode](https://github.com/jcollard/elm-mode#elm-format).
+
 ## Development info
 
 ### Building from source


### PR DESCRIPTION
I just added support for `elm-format` in `elm-mode`, figured it was worth mentioning in this README.