### PR TITLE
Use standard apostrophe

### DIFF
--- a/src/Messages/Strings.hs
+++ b/src/Messages/Strings.hs
@@ -14,7 +14,7 @@ renderMessage ErrorFileLocation = "<location>"
 
 renderMessage (FilesWillBeOverwritten filePaths) =
   unlines
-    [ "This will overwrite the following files to use Elm’s preferred style:"
+    [ "This will overwrite the following files to use Elm's preferred style:"
     , ""
     , showFiles filePaths
     , "This cannot be undone! Make sure to back up these files before proceeding."


### PR DESCRIPTION
Fixes the specific Unicode problem mentioned in https://github.com/avh4/elm-format/issues/107. There might be other instances?

Note also that the file changed here did already contain a standard apostrophe in another console string constant. So there was some inconsistency there anyway.