### PR TITLE
Refactor formatString

### DIFF
--- a/src/ElmFormat/Render/Box.hs
+++ b/src/ElmFormat/Render/Box.hs
@@ -1230,10 +1230,8 @@ formatLiteral lit =
             formatString SChar [c]
         Str s multi ->
             formatString (if multi then SMulti else SString) s
-        Boolean True ->
-            line $ literal "True"
-        Boolean False ->
-            line $ literal "False"
+        Boolean b ->
+            line $ literal $ show b
 
 
 data StringStyle
@@ -1245,69 +1243,66 @@ data StringStyle
 
 formatString :: StringStyle -> String -> Box
 formatString style s =
-    let
-        hex c =
-            if Char.ord c <= 0xFF then
-                "\\x" ++ (printf "%02X" $ Char.ord c)
-            else
-                "\\x" ++ (printf "%04X" $ Char.ord c)
+  case style of
+      SChar ->
+        stringBox "\'" id
+      SString ->
+        stringBox "\"" id
+      SMulti ->
+        stringBox "\"\"\"" escapeMultiQuote
+  where
+    stringBox quotes escaper =
+      line $ row
+          [ punc quotes
+          , literal $ escaper $ concatMap fix s
+          , punc quotes
+          ]
 
-        fix c =
-            if (style == SMulti) && c == '\n' then
-                [c]
-            else if c == '\n' then
-                "\\n"
-            else if c == '\t' then
-                "\\t"
-            else if c == '\\' then
-                "\\\\"
-            else if (style == SString) && c == '\"' then
-                "\\\""
-            else if (style == SChar) && c == '\'' then
-                "\\\'"
-            else if not $ Char.isPrint c then
-                hex c
-            else if c == ' ' then
-                [c]
-            else if c == '\xA0' then
-                [c] -- Workaround for https://github.com/elm-lang/elm-compiler/issues/1279
-            else if Char.isSpace c then
-                hex c
-            else
-                [c]
+    fix c =
+        if (style == SMulti) && c == '\n' then
+            [c]
+        else if c == '\n' then
+            "\\n"
+        else if c == '\t' then
+            "\\t"
+        else if c == '\\' then
+            "\\\\"
+        else if (style == SString) && c == '\"' then
+            "\\\""
+        else if (style == SChar) && c == '\'' then
+            "\\\'"
+        else if not $ Char.isPrint c then
+            hex c
+        else if c == ' ' then
+            [c]
+        else if c == '\xA0' then
+            [c] -- Workaround for https://github.com/elm-lang/elm-compiler/issues/1279
+        else if Char.isSpace c then
+            hex c
+        else
+            [c]
 
-        escapeMultiQuote =
-            let
-                quote =
-                    Regex.sym '"'
+    hex char =
+        "\\x" ++ (printf fmt $ Char.ord char)
+      where
+        fmt =
+          if Char.ord char <= 0xFF then
+            "%02X"
+          else
+            "%04X"
 
-                oneOrMoreQuotes =
-                    Regex.some quote
+    escapeMultiQuote =
+        let
+            quote =
+                Regex.sym '"'
 
-                escape =
-                    ("\\\"\\\"\\" ++) . (List.intersperse '\\')
-            in
-                Regex.replace $ escape <$> oneOrMoreQuotes <* quote <* quote
-    in
-        case style of
-            SChar ->
-                line $ row
-                    [ punc "\'"
-                    , literal $ concatMap fix s
-                    , punc "\'"
-                    ]
-            SString ->
-                line $ row
-                    [ punc "\""
-                    , literal $ concatMap fix s
-                    , punc "\""
-                    ]
-            SMulti ->
-                line $ row
-                    [ punc "\"\"\""
-                    , literal $ escapeMultiQuote $ concatMap fix s
-                    , punc "\"\"\""
-                    ]
+            oneOrMoreQuotes =
+                Regex.some quote
+
+            escape =
+                ("\\\"\\\"\\" ++) . (List.intersperse '\\')
+        in
+            Regex.replace $ escape <$> oneOrMoreQuotes <* quote <* quote
 
 
 data TypeParensRequired

--- a/src/ElmFormat/Render/Box.hs
+++ b/src/ElmFormat/Render/Box.hs
@@ -490,7 +490,7 @@ formatDeclaration decl =
                 AST.Declaration.TypeAnnotation name typ ->
                     formatTypeAnnotation name typ
 
-                AST.Declaration.Datatype nameWithArgs rest last ->
+                AST.Declaration.Datatype nameWithArgs middle final ->
                     let
                         ctor (tag,args') =
                             case allSingles $ map (formatHeadCommented $ formatType' ForCtor) args' of
@@ -506,9 +506,10 @@ formatDeclaration decl =
                                         ]
                     in
                         case
-                          (map (formatCommented ctor) rest) ++ [formatHeadCommented ctor last]
+                          (map (formatCommented ctor) middle) ++ [formatHeadCommented ctor final]
                         of
-                          (first:rest) ->
+                          [] -> error "List can't be empty"
+                          first:rest ->
                               case formatCommented formatNameWithArgs nameWithArgs of
                                 SingleLine nameWithArgs' ->
                                   stack1
@@ -624,6 +625,7 @@ formatDeclaration decl =
                             pleaseReport "TODO" "multiline fixity declaration"
 
 
+formatNameWithArgs :: (String, [(Comments, String)]) -> Box
 formatNameWithArgs (name, args) =
   case allSingles $ map (formatHeadCommented (line . identifier)) args of
     Right args' ->
@@ -1188,7 +1190,7 @@ formatComment comment =
             case c of
                 [] ->
                     line $ punc "{- -}"
-                (l:[]) ->
+                [l] ->
                     line $ row
                         [ punc "{-"
                         , space
@@ -1196,7 +1198,7 @@ formatComment comment =
                         , space
                         , punc "-}"
                         ]
-                (ls) ->
+                ls ->
                     stack1
                         [ prefix
                             (row [ punc "{-", space ])


### PR DESCRIPTION
Originally this was meant to address #123 which is (still) tagged as "help wanted". As I dug into it I realized the code it was concerned with no longer there. A line line `Regex.replace $ escape <$> oneOrMoreQuotes <* quote <* quote`, though cryptic, is apparently idiomatic Haskell, and it certainly gives confidence that whoever wrote it was competent.

But there was some duplicated code that gave quite a different impression, so I did my best to DRY that up. I also think this function benefits tremendously from `where` over `let` since the functions it defines don't relate to each other much.

It compiles and the tests pass.