### PR TITLE
Refactor Box.hs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,6 +2,7 @@ Copyright (c) 2015-2016, Aaron VonderHaar
 Copyright (c) 2015, Martin Janiczek
 Copyright (c) 2015, Noah Hall
 Copyright (c) 2016, Marica Odagaki
+Copyright (c) 2016, Max Goldstein
 
 All rights reserved.
 


### PR DESCRIPTION
The big win is deleting `split` in favor of `destructure` which does the same thing. Also used better variable names than `l11`. Replaced multiple definitions with case and a few other hopefully-you-like-them style tweaks.