### PR TITLE
Import multiline #139

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 Copyright (c) 2015-2016, Aaron VonderHaar
 Copyright (c) 2015, Martin Janiczek
 Copyright (c) 2015, Noah Hall
+Copyright (c) 2016, Daniel Bachler
 Copyright (c) 2016, Marica Odagaki
 
 All rights reserved.

--- a/parser/src/AST/Module.hs
+++ b/parser/src/AST/Module.hs
@@ -60,6 +60,6 @@ data UserImport
 
 data ImportMethod = ImportMethod
     { alias :: Maybe (Comments, PreCommented String)
-    , exposedVars :: (Comments, PreCommented (Var.Listing Var.Value))
+    , exposedVars :: (Comments, PreCommented (Var.Listing Var.Value), Bool)
     }
     deriving (Eq, Show)

--- a/parser/src/Parse/Module.hs
+++ b/parser/src/Parse/Module.hs
@@ -109,19 +109,16 @@ listing item =
   expecting "a listing of values and types to expose, like (..)" $
   do  (_, preParen) <- try (whitespace <* char '(')
       (_, pre) <- whitespace
+      pushNewlineContext
       listing <-
           choice
-            [ (\_ pre post -> Var.OpenListing (Commented pre () post)) <$> string ".."
-            , (\x pre post -> 
-               {- do
-                  pushNewlineContext
-                  sawNewline <- popNewlineContext
-                return $ -}
-                      Var.ExplicitListing (x pre post)) <$> commaSep1' item
+            [ (\_ pre post -> (Var.OpenListing (Commented pre () post))) <$> string ".."
+            , (\x pre post -> (Var.ExplicitListing (x pre post))) <$> commaSep1' item
             ]
+      sawNewline <- popNewlineContext
       (_, post) <- whitespace
       char ')'
-      return $ (preParen, listing pre post, False)
+      return $ (preParen, listing pre post, sawNewline)
 
 
 value :: IParser Var.Value

--- a/parser/src/Parse/Module.hs
+++ b/parser/src/Parse/Module.hs
@@ -61,7 +61,7 @@ moduleDecl =
       (_, preName) <- whitespace
       names <- dotSep1 capVar <?> "the name of this module"
       (_, postName1) <- whitespace
-      (postName2, exports) <- option ([], Var.OpenListing (Commented [] () [])) (listing value)
+      (postName2, exports, _) <- option ([], Var.OpenListing (Commented [] () []), False) (listing value)
       (_, preWhere) <- whitespace
       reserved "where"
       return (Commented preName names (postName1 ++ postName2), exports, preWhere)
@@ -88,7 +88,7 @@ import' =
     method originalName =
       Module.ImportMethod
         <$> option Nothing (Just <$> as' originalName)
-        <*> option ([], ([], Var.ClosedListing)) exposing
+        <*> option ([], ([], Var.ClosedListing), False) exposing
 
     as' :: String -> IParser (Comments, PreCommented String)
     as' moduleName =
@@ -96,15 +96,15 @@ import' =
           (_, postAs) <- whitespace
           (,) preAs <$> (,) postAs <$> capVar <?> ("an alias for module `" ++ moduleName ++ "`")
 
-    exposing :: IParser (Comments, PreCommented (Var.Listing Var.Value))
+    exposing :: IParser (Comments, PreCommented (Var.Listing Var.Value), Bool)
     exposing =
       do  (_, preExposing) <- try (whitespace <* reserved "exposing")
           (_, postExposing) <- whitespace
-          (postExposing2, listing') <- listing value
-          return (preExposing, (postExposing ++ postExposing2, listing'))
+          (postExposing2, listing', multiline) <- listing value
+          return (preExposing, (postExposing ++ postExposing2, listing'), multiline)
 
 
-listing :: IParser a -> IParser (Comments, Var.Listing a)
+listing :: IParser a -> IParser (Comments, Var.Listing a, Bool)
 listing item =
   expecting "a listing of values and types to expose, like (..)" $
   do  (_, preParen) <- try (whitespace <* char '(')
@@ -112,11 +112,16 @@ listing item =
       listing <-
           choice
             [ (\_ pre post -> Var.OpenListing (Commented pre () post)) <$> string ".."
-            , (\x pre post -> Var.ExplicitListing (x pre post)) <$> commaSep1' item
+            , (\x pre post -> 
+               {- do
+                  pushNewlineContext
+                  sawNewline <- popNewlineContext
+                return $ -}
+                      Var.ExplicitListing (x pre post)) <$> commaSep1' item
             ]
       (_, post) <- whitespace
       char ')'
-      return $ (preParen, listing pre post)
+      return $ (preParen, listing pre post, False)
 
 
 value :: IParser Var.Value
@@ -131,4 +136,4 @@ value =
           maybeCtors <- optionMaybe (listing capVar)
           case maybeCtors of
             Nothing -> return (Var.Alias name)
-            Just (pre, ctors) -> return (Var.Union (name, pre) ctors)
+            Just (pre, ctors, _) -> return (Var.Union (name, pre) ctors)

--- a/src/ElmFormat/Render/Box.hs
+++ b/src/ElmFormat/Render/Box.hs
@@ -400,8 +400,8 @@ formatImport aimport =
                                 , space
                                 , name'
                                 ]
-                              , indent $ as'
-                              , indent $ exposing'
+                              , indent as'
+                              , indent exposing'
                               ]
 
                           ( SingleLine name', Nothing, Just exposing' ) ->
@@ -417,15 +417,15 @@ formatImport aimport =
                           ( name', Just as', Just exposing' ) ->
                             stack1
                               [ line $ keyword "import"
-                              , indent $ name'
-                              , indent $ indent $ as'
-                              , indent $ indent $ exposing'
+                              , indent name'
+                              , indent $ indent as'
+                              , indent $ indent exposing'
                               ]
 
                           ( name', Nothing, Just exposing' ) ->
                             stack1
                               [ line $ keyword "import"
-                              , indent $ name'
+                              , indent name'
                               , indent $ indent exposing'
                               ]
 

--- a/src/ElmFormat/Render/Box.hs
+++ b/src/ElmFormat/Render/Box.hs
@@ -301,11 +301,14 @@ formatImport aimport =
                             "as")
                             |> Monad.join
 
+                        (exposingPreKeyword, exposingPostKeywordAndListing, multiline) 
+                          = AST.Module.exposedVars method
+
                         exposing =
                           formatImportClause
                             (formatListing formatVarValue)
                             "exposing"
-                            (AST.Module.exposedVars method)
+                            (exposingPreKeyword, exposingPostKeywordAndListing)
 
                         formatImportClause :: (a -> Maybe Box) -> String -> (Comments, (Comments, a)) -> Maybe Box
                         formatImportClause format keyw input =

--- a/tests/test-files/good/AllSyntax/BlockComments/Module.elm
+++ b/tests/test-files/good/AllSyntax/BlockComments/Module.elm
@@ -13,10 +13,8 @@ import {- L -} String
 import {- M -} Maybe {- N -} exposing {- O -} ({- S -} Maybe {- W -} ({- X -} Just {- Y -}, {- Z -} Nothing {- AA -}) {- T -}, {- U -} map {- V -})
 import {- P -} Json.Decode {- Q -} as {- R -} Json
 import Signal exposing ({- AB -} .. {- AC -})
-
-
 import Task
-  exposing 
+  exposing
     ( succeed {- AD -}
     , fail {- AE -}
     , map
@@ -32,7 +30,11 @@ import Task
     , fromMaybe
     , toResult
     , fromResult
-    ) {- AF -}
+    )
+
+
+{- AF -}
+
 
 a =
   1

--- a/tests/test-files/good/AllSyntax/BlockComments/Module.elm
+++ b/tests/test-files/good/AllSyntax/BlockComments/Module.elm
@@ -15,6 +15,25 @@ import {- P -} Json.Decode {- Q -} as {- R -} Json
 import Signal exposing ({- AB -} .. {- AC -})
 
 
+import Task
+  exposing 
+    ( succeed {- AD -}
+    , fail {- AE -}
+    , map
+    , map2
+    , map3
+    , map4
+    , map5
+    , andMap
+    , andThen
+    , onError
+    , mapError
+    , toMaybe
+    , fromMaybe
+    , toResult
+    , fromResult
+    ) {- AF -}
+
 a =
   1
 

--- a/tests/test-files/good/AllSyntax/LineComments/Module.elm
+++ b/tests/test-files/good/AllSyntax/LineComments/Module.elm
@@ -55,18 +55,18 @@ import
     as
       --R
       Json
-import
-  Signal
-    exposing
-      (--AB
-       ..
-       --AC
-      )
-
+import Signal
+  exposing
+    (--AB
+     ..
+     --AC
+    )
 import Task
-  exposing 
-    ( succeed -- AD
-    , fail -- AE
+  exposing
+    ( succeed
+      -- AD
+    , fail
+      -- AE
     , map
     , map2
     , map3
@@ -80,7 +80,11 @@ import Task
     , fromMaybe
     , toResult
     , fromResult
-    ) -- AF
+    )
+
+
+-- AF
+
 
 a =
   1

--- a/tests/test-files/good/AllSyntax/LineComments/Module.elm
+++ b/tests/test-files/good/AllSyntax/LineComments/Module.elm
@@ -63,6 +63,24 @@ import
        --AC
       )
 
+import Task
+  exposing 
+    ( succeed -- AD
+    , fail -- AE
+    , map
+    , map2
+    , map3
+    , map4
+    , map5
+    , andMap
+    , andThen
+    , onError
+    , mapError
+    , toMaybe
+    , fromMaybe
+    , toResult
+    , fromResult
+    ) -- AF
 
 a =
   1

--- a/tests/test-files/good/AllSyntax/Module.elm
+++ b/tests/test-files/good/AllSyntax/Module.elm
@@ -5,7 +5,7 @@ import Maybe exposing (Maybe(Just, Nothing), map)
 import Json.Decode as Json
 import Signal exposing (..)
 import Task
-  exposing 
+  exposing
     ( succeed
     , fail
     , map
@@ -22,6 +22,7 @@ import Task
     , toResult
     , fromResult
     )
+
 
 a =
   1

--- a/tests/test-files/good/AllSyntax/Module.elm
+++ b/tests/test-files/good/AllSyntax/Module.elm
@@ -4,7 +4,24 @@ import String
 import Maybe exposing (Maybe(Just, Nothing), map)
 import Json.Decode as Json
 import Signal exposing (..)
-
+import Task
+  exposing 
+    ( succeed
+    , fail
+    , map
+    , map2
+    , map3
+    , map4
+    , map5
+    , andMap
+    , andThen
+    , onError
+    , mapError
+    , toMaybe
+    , fromMaybe
+    , toResult
+    , fromResult
+    )
 
 a =
   1


### PR DESCRIPTION
This is my first stab at #139, getting multiline "import .. exposing()" lists to be formatted as multiline by elm-format.

This is my first PR in Haskell, so please tell me if you don't like anything or I should change something. 

I added a few test cases as you suggested and managed to get elm-format to create the according output.

There are two things I wasn't entirely sure about:

1. in parser/src/Parse/Module.hs, around line 112, I use pushNewlineContext before the choice parser. I think that this will wrongly identify import constructs as multiline if a line break occurs as part of the ".." option, but I wasn't sure what the best other way to deal with this would be. Please let me know if you think this is a problem.

2. At the output generation, I wasn't sure how best to deal with a non-SingleLine version of name, so I duplicated the 2 relevant cases and tried my best to accommodate them.

Thank you for your work!