### PR TITLE
Output validation result in a machine-readable format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /formatted.elm
 /_input.elm
 /_input2.elm
+/_stdout.txt
 /.cabal-sandbox/
 *.tix
 /.stack-work/

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ before_install:
 install:
 - stack setup
 - stack build --only-dependencies
+- npm install -g ajv-cli
 
 
 script:

--- a/README.md
+++ b/README.md
@@ -308,5 +308,6 @@ stack build
 
 ```bash
 brew install shellcheck
+node install -g ajv-cli
 ./tests/run-tests.sh
 ```

--- a/src/CommandLine/Helpers.hs
+++ b/src/CommandLine/Helpers.hs
@@ -3,7 +3,7 @@ module CommandLine.Helpers where
 import System.IO
 import System.Exit (exitFailure, exitSuccess)
 import Messages.Types (ErrorMessage(..))
-import Messages.Strings (renderErrorMessage)
+import Messages.Strings (showErrorMessage)
 
 import qualified Reporting.Annotation as RA
 import qualified Reporting.Report as Report
@@ -11,7 +11,7 @@ import qualified Reporting.Error.Syntax as Syntax
 
 
 r :: ErrorMessage -> String
-r = renderErrorMessage
+r = showErrorMessage
 
 yesOrNo :: IO Bool
 yesOrNo =

--- a/src/CommandLine/Helpers.hs
+++ b/src/CommandLine/Helpers.hs
@@ -2,16 +2,16 @@ module CommandLine.Helpers where
 
 import System.IO
 import System.Exit (exitFailure, exitSuccess)
-import Messages.Types (Message(..))
-import Messages.Strings (renderMessage)
+import Messages.Types (ErrorMessage(..))
+import Messages.Strings (renderErrorMessage)
 
 import qualified Reporting.Annotation as RA
 import qualified Reporting.Report as Report
 import qualified Reporting.Error.Syntax as Syntax
 
 
-r :: Message -> String
-r = renderMessage
+r :: ErrorMessage -> String
+r = renderErrorMessage
 
 yesOrNo :: IO Bool
 yesOrNo =
@@ -47,7 +47,7 @@ getApproval autoYes filePaths =
 
 exitOnInputDirAndOutput :: IO ()
 exitOnInputDirAndOutput = do
-    putStrLn $ r Error_SingleOutputWithMultipleInputs
+    putStrLn $ r SingleOutputWithMultipleInputs
     exitFailure
 
 

--- a/src/ElmFormat.hs
+++ b/src/ElmFormat.hs
@@ -23,7 +23,6 @@ import qualified ElmFormat.Render.Text as Render
 import qualified ElmFormat.Filesystem as FS
 import qualified Reporting.Error.Syntax as Syntax
 import qualified Reporting.Result as Result
-import qualified Messages.Formatter.HumanReadable
 import qualified System.Directory as Dir
 
 
@@ -292,7 +291,7 @@ main defaultVersion =
         config <- Flags.parse defaultVersion
         let autoYes = Flags._yes config
         let elmVersion = Flags._elmVersion config
-        let infoFormatter = Messages.Formatter.HumanReadable.format
+        let infoFormatter = Flags._infoFormatter config
 
         case determineWhatToDoFromConfig config of
             Left NoInputs ->

--- a/src/ElmFormat.hs
+++ b/src/ElmFormat.hs
@@ -150,8 +150,8 @@ resolveFiles inputFiles =
                 return $ Right $ concat files
 
 
-handleFilesInput :: [FilePath] -> Maybe FilePath -> Bool -> Bool -> ElmVersion -> InfoFormatter -> IO (Maybe Bool)
-handleFilesInput inputFiles outputFile autoYes validateOnly elmVersion formatter =
+handleFilesInput :: ElmVersion -> InfoFormatter -> [FilePath] -> Maybe FilePath -> Bool -> Bool -> IO (Maybe Bool)
+handleFilesInput elmVersion formatter inputFiles outputFile autoYes validateOnly =
     do
         elmFiles <- resolveFiles inputFiles
 
@@ -267,7 +267,7 @@ validate elmVersion formatter source =
                             |> processTextInput elmVersion formatter ValidateOnly "<STDIN>"
 
                 FromFiles first rest ->
-                    handleFilesInput (first:rest) Nothing True True elmVersion formatter
+                    handleFilesInput elmVersion formatter (first:rest) Nothing True True
 
         case result of
             Nothing ->
@@ -307,7 +307,7 @@ main defaultVersion =
 
             Right (FormatInPlace first rest) ->
                 do
-                    result <- handleFilesInput (first:rest) Nothing autoYes False elmVersion infoFormatter
+                    result <- handleFilesInput elmVersion infoFormatter (first:rest) Nothing autoYes False
                     case result of
                         Nothing ->
                             exitSuccess
@@ -317,7 +317,7 @@ main defaultVersion =
 
             Right (FormatToFile input output) ->
                 do
-                    result <- handleFilesInput [input] (Just output) autoYes False elmVersion infoFormatter
+                    result <- handleFilesInput elmVersion infoFormatter [input] (Just output) autoYes False
                     case result of
                         Nothing ->
                             exitSuccess

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -4,9 +4,12 @@ module Flags where
 import Data.Monoid ((<>))
 import Data.Version (showVersion)
 import ElmVersion (ElmVersion(..))
+import Messages.Formatter.Format (InfoFormatter)
 
+import qualified Data.List as List
 import qualified Data.Maybe as Maybe
 import qualified ElmVersion
+import qualified Messages.Formatter as Formatter
 import qualified Options.Applicative as Opt
 import qualified Paths_elm_format as This
 import qualified Text.PrettyPrint.ANSI.Leijen as PP
@@ -19,6 +22,7 @@ data Config = Config
     , _validate :: Bool
     , _stdin :: Bool
     , _elmVersion :: ElmVersion
+    , _infoFormatter :: InfoFormatter
     }
 
 
@@ -85,6 +89,7 @@ flags defaultVersion =
       <*> validate
       <*> stdin
       <*> elmVersion defaultVersion
+      <*> infoFormatter
 
 
 
@@ -181,5 +186,24 @@ elmVersion defaultVersion =
             , show ElmVersion.Elm_0_16 ++ ", "
             , show ElmVersion.Elm_0_17 ++ ".  "
             , "Default: " ++ show defaultVersion
+            ]
+      ]
+
+
+infoFormatter :: Opt.Parser InfoFormatter
+infoFormatter =
+  fmap (Maybe.fromMaybe Formatter.defaultFormatter) $
+  Opt.optional $
+  Opt.option (Opt.eitherReader Formatter.readFormatter) $
+    mconcat
+      [ Opt.long "format"
+      , Opt.metavar "FORMAT"
+      , Opt.help $
+          concat
+            [ "Output format.  "
+            , "Valid values: "
+            , (List.intercalate ", " Formatter.orderedFormatterNames)
+            , ".  "
+            , "Default: " ++ Formatter.defaultFormatterName
             ]
       ]

--- a/src/Messages/Formatter.hs
+++ b/src/Messages/Formatter.hs
@@ -1,0 +1,36 @@
+{-# OPTIONS_GHC -Wall #-}
+module Messages.Formatter where
+
+import Messages.Formatter.Format
+
+import qualified Messages.Formatter.HumanReadable as HumanReadable
+import qualified Data.Map as Map
+import qualified Data.List as List
+
+
+defaultFormatterName :: String
+defaultFormatterName = "human-readable"
+
+
+defaultFormatter :: InfoFormatter
+defaultFormatter = HumanReadable.format
+
+
+formatters :: Map.Map String (InfoFormatter)
+formatters = Map.fromList [
+    (defaultFormatterName, defaultFormatter)
+    ]
+
+
+orderedFormatterNames :: [String]
+orderedFormatterNames =
+    List.sort . Map.keys $ formatters
+
+
+readFormatter :: String -> Either String InfoFormatter
+readFormatter name =
+    case Map.lookup name formatters of
+        Nothing ->
+            Left $ "No formatter known by the name of " ++ name
+        Just f ->
+            Right f

--- a/src/Messages/Formatter.hs
+++ b/src/Messages/Formatter.hs
@@ -3,6 +3,7 @@ module Messages.Formatter where
 
 import Messages.Formatter.Format
 
+import qualified Messages.Formatter.Json as Json
 import qualified Messages.Formatter.HumanReadable as HumanReadable
 import qualified Data.Map as Map
 import qualified Data.List as List
@@ -18,7 +19,8 @@ defaultFormatter = HumanReadable.format
 
 formatters :: Map.Map String (InfoFormatter)
 formatters = Map.fromList [
-    (defaultFormatterName, defaultFormatter)
+    (defaultFormatterName, defaultFormatter),
+    ("json", Json.format)
     ]
 
 

--- a/src/Messages/Formatter/Format.hs
+++ b/src/Messages/Formatter/Format.hs
@@ -1,0 +1,10 @@
+{-# OPTIONS_GHC -Wall #-}
+module Messages.Formatter.Format (InfoFormatter(..)) where
+
+
+import Messages.Types
+
+
+data InfoFormatter = InfoFormatter
+  { onInfo :: InfoMessage -> IO ()
+  }

--- a/src/Messages/Formatter/HumanReadable.hs
+++ b/src/Messages/Formatter/HumanReadable.hs
@@ -1,0 +1,26 @@
+{-# OPTIONS_GHC -Wall #-}
+module Messages.Formatter.HumanReadable (format) where
+
+import Messages.Formatter.Format
+import Messages.Types
+
+
+format :: InfoFormatter
+format = InfoFormatter
+    { onInfo = renderInfo }
+
+
+renderInfo :: InfoMessage -> IO ()
+
+renderInfo (ProcessingFiles files) =
+    case files of
+        file:[] ->
+            putStrLn $ "Processing file " ++ file
+        _ ->
+            putStrLn $ "Processing multiple files..."
+
+renderInfo (FileWouldChange file) =
+    putStrLn $ "File would be changed " ++ file
+
+renderInfo _ =
+    return ()

--- a/src/Messages/Formatter/Json.hs
+++ b/src/Messages/Formatter/Json.hs
@@ -1,0 +1,30 @@
+{-# OPTIONS_GHC -Wall #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Messages.Formatter.Json (format) where
+
+import Data.Aeson ((.=))
+import qualified Data.Aeson as Json
+import qualified Data.ByteString.Lazy as B
+import qualified Data.ByteString.Lazy.Char8 as BC
+
+import Messages.Formatter.Format
+import Messages.Types
+
+
+format :: InfoFormatter
+format = InfoFormatter
+    { onInfo = (\m -> maybe (return ()) BC.putStrLn $ showInfo m) }
+
+
+showInfo :: InfoMessage -> Maybe B.ByteString
+
+showInfo (ProcessingFiles _) =
+    Nothing
+
+showInfo (FileWouldChange file) =
+    Just $ Json.encode $ Json.object
+        [ "path" .= file
+        , "line" .= (1 :: Int)
+        , "column" .= (1 :: Int)
+        , "message" .= ("File would be changed" :: String)
+        ]

--- a/src/Messages/Strings.hs
+++ b/src/Messages/Strings.hs
@@ -8,11 +8,11 @@ showFiles :: [FilePath] -> String
 showFiles = unlines . map ((++) "    ")
 
 
-renderErrorMessage :: ErrorMessage -> String
+showErrorMessage :: ErrorMessage -> String
 
-renderErrorMessage ErrorsHeading = "ERRORS"
+showErrorMessage ErrorsHeading = "ERRORS"
 
-renderErrorMessage (FilesWillBeOverwritten filePaths) =
+showErrorMessage (FilesWillBeOverwritten filePaths) =
   unlines
     [ "This will overwrite the following files to use Elm's preferred style:"
     , ""
@@ -23,7 +23,7 @@ renderErrorMessage (FilesWillBeOverwritten filePaths) =
     ]
 
 
-renderErrorMessage (BadInputFiles filePaths) =
+showErrorMessage (BadInputFiles filePaths) =
   unlines
     [ "There was a problem reading one or more of the specified input files:"
     , ""
@@ -31,17 +31,17 @@ renderErrorMessage (BadInputFiles filePaths) =
     , "Please check the given paths."
     ]
 
-renderErrorMessage SingleOutputWithMultipleInputs =
+showErrorMessage SingleOutputWithMultipleInputs =
   unlines
     [ "Can't write to the OUTPUT path, because multiple .elm files have been specified."
     , ""
     , "Please remove the --output argument. The .elm files in INPUT will be formatted in place."
     ]
 
-renderErrorMessage TooManyInputs =
+showErrorMessage TooManyInputs =
     "Too many input sources! Please only provide one of either INPUT or --stdin"
 
-renderErrorMessage OutputAndValidate =
+showErrorMessage OutputAndValidate =
     "Cannot use --output and --validate together"
 
 

--- a/src/Messages/Strings.hs
+++ b/src/Messages/Strings.hs
@@ -8,11 +8,11 @@ showFiles :: [FilePath] -> String
 showFiles = unlines . map ((++) "    ")
 
 
-renderMessage :: Message -> String
+renderErrorMessage :: ErrorMessage -> String
 
-renderMessage ErrorsHeading = "ERRORS"
+renderErrorMessage ErrorsHeading = "ERRORS"
 
-renderMessage (FilesWillBeOverwritten filePaths) =
+renderErrorMessage (FilesWillBeOverwritten filePaths) =
   unlines
     [ "This will overwrite the following files to use Elm's preferred style:"
     , ""
@@ -23,7 +23,7 @@ renderMessage (FilesWillBeOverwritten filePaths) =
     ]
 
 
-renderMessage (BadInputFiles filePaths) =
+renderErrorMessage (BadInputFiles filePaths) =
   unlines
     [ "There was a problem reading one or more of the specified input files:"
     , ""
@@ -31,27 +31,17 @@ renderMessage (BadInputFiles filePaths) =
     , "Please check the given paths."
     ]
 
-renderMessage Error_SingleOutputWithMultipleInputs =
+renderErrorMessage SingleOutputWithMultipleInputs =
   unlines
     [ "Can't write to the OUTPUT path, because multiple .elm files have been specified."
     , ""
     , "Please remove the --output argument. The .elm files in INPUT will be formatted in place."
     ]
 
-renderMessage (ProcessingFiles files) =
-    case files of
-        file:[] ->
-            "Processing file " ++ file
-        _ ->
-            "Processing multiple files..."
-
-renderMessage (FileWouldChange file) =
-    "File would be changed " ++ file
-
-renderMessage Error_TooManyInputs =
+renderErrorMessage TooManyInputs =
     "Too many input sources! Please only provide one of either INPUT or --stdin"
 
-renderMessage Error_OutputAndValidate =
+renderErrorMessage OutputAndValidate =
     "Cannot use --output and --validate together"
 
 

--- a/src/Messages/Types.hs
+++ b/src/Messages/Types.hs
@@ -4,17 +4,20 @@ module Messages.Types where
 -- inspired by:
 -- https://wiki.haskell.org/Internationalization_of_Haskell_programs_using_Haskell_data_types
 
-data Message
+data InfoMessage
+  = ProcessingFiles [FilePath]
+  | FileWouldChange FilePath
+
+
+data ErrorMessage
   = ErrorsHeading
 
   | FilesWillBeOverwritten [FilePath]
   | BadInputFiles [InputFileMessage]
-  | Error_NoInputs
-  | Error_SingleOutputWithMultipleInputs
-  | Error_TooManyInputs
-  | Error_OutputAndValidate
-  | ProcessingFiles [FilePath]
-  | FileWouldChange FilePath
+  | NoInputs
+  | SingleOutputWithMultipleInputs
+  | TooManyInputs
+  | OutputAndValidate
 
 
 data InputFileMessage

--- a/tests/ElmFormat/CliTest/Usage.stdout
+++ b/tests/ElmFormat/CliTest/Usage.stdout
@@ -13,8 +13,8 @@ Available options:
   --stdin                  Read from stdin, output to stdout.
   --elm-version VERSION    The Elm version of the source files being formatted.
                            Valid values: 0.16, 0.17. Default: 0.17
-  --format FORMAT          Output format. Valid values: human-readable. Default:
-                           human-readable
+  --format FORMAT          Output format. Valid values: human-readable, json.
+                           Default: human-readable
 
 Examples:
   elm-format Main.elm                     # formats Main.elm

--- a/tests/ElmFormat/CliTest/Usage.stdout
+++ b/tests/ElmFormat/CliTest/Usage.stdout
@@ -1,7 +1,7 @@
 elm-format-0.17 0.4.1-alpha-dev
 
 Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
-                  [--elm-version VERSION]
+                  [--elm-version VERSION] [--format FORMAT]
   Format an Elm source file.
 
 Available options:
@@ -13,6 +13,8 @@ Available options:
   --stdin                  Read from stdin, output to stdout.
   --elm-version VERSION    The Elm version of the source files being formatted.
                            Valid values: 0.16, 0.17. Default: 0.17
+  --format FORMAT          Output format. Valid values: human-readable. Default:
+                           human-readable
 
 Examples:
   elm-format Main.elm                     # formats Main.elm

--- a/tests/json-format-schema.json
+++ b/tests/json-format-schema.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties": {
+    "path": {
+      "type": "string"
+    },
+    "line": {
+      "type": "number"
+    },
+    "column": {
+      "type": "number"
+    },
+    "message": {
+      "type": "string"
+    }
+  },
+  "required": ["path", "line", "column", "message"]
+}

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -87,7 +87,7 @@ function checkWaysToRun() {
 	"$ELM_FORMAT" "$INPUT_2" --validate 1>/dev/null
 	returnCodeShouldEqual 1
 
-	echo "## elm-format INPUT --validate with formatted file exits 1"
+	echo "## elm-format INPUT --validate with formatted file exits 0"
 	"$ELM_FORMAT" "$INPUT_2" --yes 1>/dev/null
 	"$ELM_FORMAT" "$INPUT_2" --validate 1>/dev/null
 	returnCodeShouldEqual 0


### PR DESCRIPTION
## Motivation

We run `elm-format --validate` in our CI builds to enforce standard code formatting. Being able to save the validation result in a standard machine-friendly format allows a tighter integration with the CI server (Jenkins in our case), leading to better visibility of which files failed the build for what reason.
## Intended usage

```
elm-format --validate --format json app spec
```

To convert to checkstyle's xml format:

```
elm-format --validate --format json app spec | jq -n -r -f checkstyle.jq > elm-format-validation-result.xml
```

checkstyle.jq is from [this gist](https://gist.github.com/ento/a4e2a251f54fe531ede9a8cd1960c7d6#file-checkstyle-jq). I'll push it to [elm-ops-tooling](https://github.com/NoRedInk/elm-ops-tooling) once this PR is merged.
## Limitations, concerns and notes
- Only reports which files failed validation, not the exact lines that failed
- Having a `--format` option for a binary called `x-format` might be confusing
- Code organization inspired by [shellcheck](https://github.com/koalaman/shellcheck/tree/dbafbb3b3b0e6d8d04b99f42f8816dada44fe216/ShellCheck/Formatter)
## Input/Output sample

``` sh
$ cp "tests/test-files/transform/Examples.elm" "_input.elm"
$ cp "tests/test-files/transform/Examples.elm" "_input2.elm"
$ ./dist/build/elm-format-0.17/elm-format-0.17 _input.elm _input2.elm --validate --format json
```

outputs:

``` json
{"path":"_input2.elm","line":1,"message":"File would be changed","column":1}
{"path":"_input.elm","line":1,"message":"File would be changed","column":1}
```
