### PR TITLE
Add npm installer

### DIFF
--- a/package/npm/.eslintrc.yml
+++ b/package/npm/.eslintrc.yml
@@ -1,0 +1,6 @@
+extends: eslint:recommended
+env:
+  node: true
+  es6: true
+rules:
+  no-console: off

--- a/package/npm/.gitignore
+++ b/package/npm/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bin/

--- a/package/npm/.gitignore
+++ b/package/npm/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 bin/
+*.log

--- a/package/npm/README.md
+++ b/package/npm/README.md
@@ -1,0 +1,20 @@
+npm package for elm-format
+==========================
+
+This package installs [`elm-format`](https://github.com/avh4/elm-format) via [`npm`](https://www.npmjs.com/).
+
+## Usage
+
+```
+npm install -g elm-format@0.4.0-alpha
+```
+
+This will install the binaries `elm-format` and `elm-format-0.16` to your global `node_modules`.
+
+## Publishing
+
+Publishing npm packages follows the [procedure stated in the official npm docs](https://docs.npmjs.com/getting-started/publishing-npm-packages).
+
+### Bumping `elm-format` version
+
+The downloaded binary version will follow the one stated in `package.json`. If `elm format` is updated, this package can be bumped by only updating the `version` field in the `package.json` (given that the download url structure does not change).

--- a/package/npm/binwrap.js
+++ b/package/npm/binwrap.js
@@ -8,9 +8,11 @@ module.exports = function(executable) {
 
   const os = process.platform;
 
-  const extension = os === 'win32' ? '.exe' : '';
-  const filename = `${executable}${extension}`;
+  // Unzipping the Windows .zip puts the .exe inside the directory,
+  // while the .tgz will produce just the right binary files with
+  // the same name as the executable. path.join will ignore empty strings.
+  const binaryFile = os === 'win32' ? 'elm-format.exe' : '';
 
-  spawn(path.join(distDir, filename), input, { stdio: 'inherit' })
+  spawn(path.join(distDir, executable, binaryFile), input, { stdio: 'inherit' })
     .on('exit', process.exit);
 };

--- a/package/npm/binwrap.js
+++ b/package/npm/binwrap.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const spawn = require("child_process").spawn;
+const spawn = require('child_process').spawn;
 
 const distDir = require('./config').distDir;
 

--- a/package/npm/binwrap.js
+++ b/package/npm/binwrap.js
@@ -1,0 +1,16 @@
+const path = require('path');
+const spawn = require("child_process").spawn;
+
+const distDir = require('./config').distDir;
+
+module.exports = function(executable) {
+  var input = process.argv.slice(2);
+
+  const os = process.platform;
+
+  const extension = os === 'win32' ? '.exe' : '';
+  const filename = `${executable}${extension}`;
+
+  spawn(path.join(distDir, filename), input, { stdio: 'inherit' })
+    .on('exit', process.exit);
+};

--- a/package/npm/binwrappers/elm-format-0.16
+++ b/package/npm/binwrappers/elm-format-0.16
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-const path = require("path");
+const path = require('path');
 
 require(path.join('..', 'binwrap.js'))('elm-format-0.16');

--- a/package/npm/binwrappers/elm-format-0.16
+++ b/package/npm/binwrappers/elm-format-0.16
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+require(path.join('..', 'binwrap.js'))('elm-format-0.16');

--- a/package/npm/binwrappers/elm-format-0.17
+++ b/package/npm/binwrappers/elm-format-0.17
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-const path = require("path");
+const path = require('path');
 
 require(path.join('..', 'binwrap.js'))('elm-format-0.17');

--- a/package/npm/binwrappers/elm-format-0.17
+++ b/package/npm/binwrappers/elm-format-0.17
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+const path = require("path");
+
+require(path.join('..', 'binwrap.js'))('elm-format-0.17');

--- a/package/npm/config.js
+++ b/package/npm/config.js
@@ -1,5 +1,8 @@
 const path = require('path');
 
+const packageInfo = require(path.join(__dirname, 'package.json'));
+
 module.exports = {
   distDir: path.join(__dirname, 'bin'),
+  elmFormatVersion: packageInfo.version,
 };

--- a/package/npm/config.js
+++ b/package/npm/config.js
@@ -1,0 +1,5 @@
+const path = require('path');
+
+module.exports = {
+  distDir: path.join(__dirname, 'bin'),
+};

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -7,7 +7,7 @@ const mkdirp = require('mkdirp');
 
 const distDir = require('./config').distDir;
 
-const ELM_FORMAT_VERSION = '0.4.0-alpha';
+const elmFormatVersion = require('./config').elmFormatVersion;
 
 getDownloadUrls()
   .then(downloadAndUnpackBinaries)
@@ -56,11 +56,11 @@ function getDownloadUrls() {
     );
 
     function versionToFilename(version) {
-      return `elm-format-${version}-${ELM_FORMAT_VERSION}-${os}-${arch}.${extension}`;
+      return `elm-format-${version}-${elmFormatVersion}-${os}-${arch}.${extension}`;
     }
 
     function filenameToDownloadUrl(filename) {
-      return `https://github.com/avh4/elm-format/releases/download/${ELM_FORMAT_VERSION}/${filename}`
+      return `https://github.com/avh4/elm-format/releases/download/${elmFormatVersion}/${filename}`
     }
   })
 }

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -1,13 +1,13 @@
 const fs = require('fs');
-const path = require('path');
 const zlib = require('zlib');
 const request = require('request');
 const tar = require('tar');
 const unzip = require('unzip');
 const mkdirp = require('mkdirp');
 
+const distDir = require('./config').distDir;
+
 const ELM_FORMAT_VERSION = '0.4.0-alpha';
-const distDir = path.join(__dirname, 'bin');
 
 getDownloadUrls()
   .then(downloadAndUnpackBinaries)
@@ -66,6 +66,7 @@ function getDownloadUrls() {
 }
 
 function downloadAndUnpackBinaries(downloadObjects) {
+  console.log('Downloading binaries...');
   return Promise.all(downloadObjects.map(downloadAndUnpack));
 }
 

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -119,16 +119,6 @@ function downloadAndUnpack(downloadObject) {
         );
       }
 
-      if (!fs.statSync(distDir).isDirectory()) {
-        reject(
-          'Error extracting executables: extraction finished, but' +
-          distDir + 'ended up being a file, not a directory. ' +
-          'This can happen when the .tar.gz file contained the ' +
-          'binaries directly, instead of containing a directory with ' +
-          'the files inside.'
-        );
-      }
-
       resolve('Successfully downloaded and processed ' + downloadObject.filename);
     }
   });

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -1,0 +1,134 @@
+const fs = require('fs');
+const path = require('path');
+const zlib = require('zlib');
+const request = require('request');
+const tar = require('tar');
+const unzip = require('unzip');
+const mkdirp = require('mkdirp');
+
+const ELM_FORMAT_VERSION = '0.4.0-alpha';
+const distDir = path.join(__dirname, 'bin');
+
+getDownloadUrls()
+  .then(downloadAndUnpackBinaries)
+  .then(successMessages => {
+    successMessages.forEach(message => {
+      console.log(message);
+    });
+  })
+  .catch(errorMessage => {
+    console.error(errorMessage);
+    process.exit(1);
+  });
+
+function getDownloadUrls() {
+  return new Promise((resolve, reject) => {
+    const availableOs = {
+      darwin: 'mac',
+      linux: 'linux',
+      win32: 'win',
+    };
+
+    const availableArch = {
+      x64: 'x64',
+    };
+
+    const os = availableOs[process.platform];
+    const arch = availableArch[process.arch];
+
+    if (!os || !arch) {
+      return reject('Sorry, there are currently no available elm-format binary for your operating system and architecture.');
+    }
+
+    const extension = os === 'win' ? 'zip' : 'tgz';
+
+    const elmVersions = [
+      '0.16',
+      '0.17',
+    ];
+
+    return resolve(
+      elmVersions.map(version => ({
+        version,
+        filename: versionToFilename(version),
+        url: filenameToDownloadUrl(versionToFilename(version))
+      }))
+    );
+
+    function versionToFilename(version) {
+      return `elm-format-${version}-${ELM_FORMAT_VERSION}-${os}-${arch}.${extension}`;
+    }
+
+    function filenameToDownloadUrl(filename) {
+      return `https://github.com/avh4/elm-format/releases/download/${ELM_FORMAT_VERSION}/${filename}`
+    }
+  })
+}
+
+function downloadAndUnpackBinaries(downloadObjects) {
+  return Promise.all(downloadObjects.map(downloadAndUnpack));
+}
+
+function downloadAndUnpack(downloadObject) {
+  return new Promise((resolve, reject) => {
+    const gunzip = zlib.createGunzip()
+      .on('error', (err) => {
+        reject(`Error decompressing ${downloadObject.filename} ${err}`);
+      });
+
+    const untar = tar.Extract({ path: `${distDir}/elm-format-${downloadObject.version}`, strip: 1 })
+      .on('error', (err) => {
+        reject(`Error decompressing ${downloadObject.filename} ${err}`);
+      })
+      .on('end', onEnd);
+
+    const extractZip = unzip.Extract({ path: `${distDir}/elm-format-${downloadObject.version}` })
+      .on('end', onEnd);
+
+    const req = request.get(downloadObject.url, (err, response) => {
+      if (err) {
+        return reject(`Error communicating with URL ${downloadObject.url}`);
+      }
+
+      if (response.statusCode !== 200) {
+        return reject(`Error: URL is returning status code other than 200: ${response.statusCode}`);
+      }
+
+      if (!fs.existsSync(distDir)) {
+        mkdirp.sync(distDir);
+      }
+
+      response.on('error', (err) => {
+        reject(`Error receiving ${downloadObject.url} ${err}`);
+      });
+    });
+
+    if (process.platform === 'win32') {
+      req.pipe(extractZip);
+    } else {
+      req.pipe(gunzip).pipe(untar);
+    }
+
+    function onEnd() {
+      if (!fs.existsSync(distDir)) {
+        reject(
+          'Error extracting executables: extraction finished, but',
+          distDir, 'directory was not created.\n' +
+          'Current directory contents: ' + fs.readdirSync(__dirname)
+        );
+      }
+
+      if (!fs.statSync(distDir).isDirectory()) {
+        reject(
+          'Error extracting executables: extraction finished, but' +
+          distDir + 'ended up being a file, not a directory. ' +
+          'This can happen when the .tar.gz file contained the ' +
+          'binaries directly, instead of containing a directory with ' +
+          'the files inside.'
+        );
+      }
+
+      resolve('Successfully downloaded and processed ' + downloadObject.filename);
+    }
+  });
+}

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -21,5 +21,14 @@
   "bugs": {
     "url": "https://github.com/avh4/elm-format/issues"
   },
-  "homepage": "https://github.com/avh4/elm-format#readme"
+  "homepage": "https://github.com/avh4/elm-format#readme",
+  "dependencies": {
+    "mkdirp": "^0.5.1",
+    "request": "^2.75.0",
+    "tar": "^2.2.1",
+    "unzip": "^0.1.11"
+  },
+  "devDependencies": {
+    "eslint": "^3.6.0"
+  }
 }

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -2,9 +2,13 @@
   "name": "elm-format",
   "version": "0.4.0-alpha",
   "description": "elm-format formats Elm source code according to a standard set of rules based on the official Elm Style Guide",
-  "main": "index.js",
+  "preferGlobal": true,
+  "bin": {
+    "elm-format": "binwrappers/elm-format-0.17",
+    "elm-format-0.16": "binwrappers/elm-format-0.16"
+  },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "install": "node install.js"
   },
   "repository": {
     "type": "git",

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "elm-format",
+  "version": "0.4.0-alpha",
+  "description": "elm-format formats Elm source code according to a standard set of rules based on the official Elm Style Guide",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/avh4/elm-format.git"
+  },
+  "keywords": [
+    "bin",
+    "binary",
+    "elm",
+    "elm-format"
+  ],
+  "author": "",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/avh4/elm-format/issues"
+  },
+  "homepage": "https://github.com/avh4/elm-format#readme"
+}


### PR DESCRIPTION
As stated in #84, here is the result of my fiddling with npm installer for `elm-format`. I'm drawing many examples from [`elm-platform` npm installers](https://github.com/elm-lang/elm-platform/tree/master/installers/npm). I'm putting the installer at `package/npm` directory (may be moved if you wanted to).

Some questions, though:
1. I was thinking of creating my own repo rather than forking and creating a dir in this repo's `package`, but decided not to just to keep it centralized. Should I have done that instead?
2. I still have no idea what to export for local npm installation and use by `require`. Will exporting the binary paths (like `elm-platform` does) be enough?
3. I've referred the publishing process to the npm official docs on the README (along with some notes on version bumping). Please tell me if I need to add something more.

I've tested this by running `npm install -g .` inside the `package/npm` directory and it successfully downloaded and installed `elm-format` to my global module. Not publishing it to npm yet since npm have a kind of [restrictive publishing policy](http://blog.npmjs.org/post/141905368000/changes-to-npms-unpublish-policy).

Kindly take a look? @avh4 @eeue56 
