### PR TITLE
Details for adding user keymap entries in lighttable

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,14 +189,13 @@ The default behavior of `elm-format`-approved plugins is to format Elm files on 
 
 1. Install elm-format
 1. Install the [elm-light plugin](https://github.com/rundis/elm-light) using the Light Table plugin manager
-1. Add the following to your user keymap:
+1. Use the command pallete to run "Settings: User behaviors" and add the following:
 
   ```clojure
-  [:editor.elm "ctrl-s" :save :elm-format :elm.lint]
+  ;; Elm behaviors on save
+  [:editor.elm :lt.objs.editor.file/on-save :elm-format]
+  [:editor.elm :lt.objs.editor.file/on-save :elm.lint]
   ```
-  
-  > This step needs improvement to be understandable by novice Light Table users:
-  > how does one edit the user keymap?
 
 
 ### elm-mode installation


### PR DESCRIPTION
I'm new to Lighttable, so hopefully these improved instructions would work for other novices.

After spending a few hours improving my Lighttable configuration, I found that using the on-save hook was more correct than re-binding ctrl-s. This allows users who have save-on-focus-lost configured to benefit from formatting as well.