### PR TITLE
Make it more clear that multiple Elm files can be formatted as a batch

### DIFF
--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -95,7 +95,7 @@ helpInfo defaultVersion =
     mconcat
         [ Opt.fullDesc
         , Opt.header top
-        , Opt.progDesc "Format an Elm source file."
+        , Opt.progDesc "Format Elm source files."
         , Opt.footerDoc (Just examples)
         ]
   where
@@ -110,6 +110,7 @@ helpInfo defaultVersion =
         [ "Examples:"
         , "  elm-format Main.elm                     # formats Main.elm"
         , "  elm-format Main.elm --output Main2.elm  # formats Main.elm as Main2.elm"
+        , "  elm-format src/                         # format all *.elm files in the src directory"
         , ""
         , "Full guide to using elm-format at <https://github.com/avh4/elm-format>"
         ]

--- a/tests/ElmFormat/CliTest/Usage.stdout
+++ b/tests/ElmFormat/CliTest/Usage.stdout
@@ -2,7 +2,7 @@ elm-format-0.17 0.4.1-alpha-dev
 
 Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
                   [--elm-version VERSION]
-  Format an Elm source file.
+  Format Elm source files.
 
 Available options:
   -h,--help                Show this help text
@@ -17,5 +17,6 @@ Available options:
 Examples:
   elm-format Main.elm                     # formats Main.elm
   elm-format Main.elm --output Main2.elm  # formats Main.elm as Main2.elm
+  elm-format src/                         # format all *.elm files in the src directory
 
 Full guide to using elm-format at <https://github.com/avh4/elm-format>


### PR DESCRIPTION
The CLI help docs made it seem like elm-format could only be invoked
against a single Elm source file, but the README includes an example
of how elm-format can be used to recursively format all .elm files
in a directory. This change brings the CLI help docs in-line with the
README and the capabilities of the tool.