### PR TITLE
Fix 'ERROR:not found' while `./tests/run-tests.sh`

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -6,7 +6,7 @@
 
 stack build || exit 1
 
-ELM_FORMAT="`ls ./.stack-work/install/*/lts-7.4/8.0.1/bin/elm-format-0.17 | head -n1`"
+ELM_FORMAT="`ls ./.stack-work/install/*/lts-7.4/8.0.1*/bin/elm-format-0.17 | head -n1`"
 if [ ! -e "$ELM_FORMAT" ]; then
 	echo "$0: ERROR: $ELM_FORMAT not found" >&2
 	exit 1


### PR DESCRIPTION
Fix `./tests/run-tests.sh: ERROR:  not found' on macOS

```
Installing executable(s) in
**/elm-format/.stack-work/install/x86_64-osx/lts-7.4/8.0.1.20161022/bin
ls: ./.stack-work/install/*/lts-7.4/8.0.1/bin/elm-format-0.17: No such file or directory
./tests/run-tests.sh: ERROR:  not found
```