### PR TITLE
Add npm installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 *.tix
 /.stack-work/
 /tests/elm-format
-node_modules/
+/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 *.tix
 /.stack-work/
 /tests/elm-format
-/node_modules/

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -56,7 +56,6 @@ brew cask install virtualbox
 
 ```
 cd package/npm
-# TODO: ensure that the required URLs all exist
 npm publish
 ```
 

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -20,6 +20,7 @@ brew cask install virtualbox
 1. Create a github issue to draft the release notes.
 1. Edit `elm-format.cabal` to remove `-dev` from the version and make sure the version number is correct.
 1. Edit `CHANGELOG.md` to set the correct version number.
+1. `(cd package/npm && npm version "$(git describe --abbrev=8)")`
 1. Commit the changes.
 1. Create a signed tag for the new version. `git tag -s <version> -m <version>`
 1. Push the tag.
@@ -49,6 +50,15 @@ brew cask install virtualbox
 1. Write the release notes.
 1. Publish the release.
 1. Update `README.md`
+
+
+## NPM
+
+```
+cd package/npm
+# TODO: ensure that the required URLs all exist
+npm publish
+```
 
 
 ## Clean up

--- a/package/npm/.eslintrc.json
+++ b/package/npm/.eslintrc.json
@@ -1,0 +1,11 @@
+{
+    "env": {
+        "node": true,
+        "mocha": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "no-console": "off"
+    }
+}

--- a/package/npm/.gitignore
+++ b/package/npm/.gitignore
@@ -1,0 +1,1 @@
+/node_modules/

--- a/package/npm/README.md
+++ b/package/npm/README.md
@@ -1,0 +1,2 @@
+
+See [https://github.com/avh4/elm-format](https://github.com/avh4/elm-format)

--- a/package/npm/binaries/elm-format
+++ b/package/npm/binaries/elm-format
@@ -1,1 +1,5 @@
-echo "The npm installation of elm-format did not complete successfully! Please try reinstalling elm-format through npm. If you still see this message even after reinstalling, please file a bug at https://github.com/avh4/elm-format/issues to let us know. You can find manual installers at https://github.com/avh4/elm-format"
+#!/bin/sh
+
+echo "ERROR: The npm installation of elm-format did not complete successfully! Please try reinstalling elm-format through npm. If you still see this message even after reinstalling, please file a bug at https://github.com/avh4/elm-format/issues to let us know. You can find manual installers at https://github.com/avh4/elm-format#installation-"
+
+exit 1

--- a/package/npm/elmFormatDownload.js
+++ b/package/npm/elmFormatDownload.js
@@ -3,18 +3,32 @@ var path = require("path");
 exports.url = function(operatingSystem, arch) {
   // 'arm', 'ia32', or 'x64'.
   arch = arch || process.arch;
+  arch = {}[arch] || arch;
 
   // 'darwin', 'freebsd', 'linux', 'sunos' or 'win32'
   operatingSystem = operatingSystem || process.platform;
+  operatingSystem = {
+    darwin: "mac",
+    win32: "win"
+  }[operatingSystem] || operatingSystem;
+
+  var ext = {
+    win: "zip"
+  }[operatingSystem] || "tgz";
 
   var packageInfo = require(path.join(__dirname, "package.json"));
   var binVersion = packageInfo.version;
 
-  var filename = operatingSystem + "-" + arch + ".tar.gz";
-  var url = "https://dl.bintray.com/elmlang/elm-format/default/" +
+  var url = "https://github.com/avh4/elm-format/releases/download/" +
     binVersion +
-    "/" +
-    filename;
+    "/elm-format-0.18-" +
+    binVersion +
+    "-" +
+    operatingSystem +
+    "-" +
+    arch +
+    "." +
+    ext;
 
   return url;
 };

--- a/package/npm/elmFormatDownload.js
+++ b/package/npm/elmFormatDownload.js
@@ -1,0 +1,20 @@
+var path = require("path");
+
+exports.url = function(operatingSystem, arch) {
+  // 'arm', 'ia32', or 'x64'.
+  arch = arch || process.arch;
+
+  // 'darwin', 'freebsd', 'linux', 'sunos' or 'win32'
+  operatingSystem = operatingSystem || process.platform;
+
+  var packageInfo = require(path.join(__dirname, "package.json"));
+  var binVersion = packageInfo.version;
+
+  var filename = operatingSystem + "-" + arch + ".tar.gz";
+  var url = "https://dl.bintray.com/elmlang/elm-format/default/" +
+    binVersion +
+    "/" +
+    filename;
+
+  return url;
+};

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -1,21 +1,7 @@
 var binstall = require("binstall");
 var path = require("path");
 var fs = require("fs");
-var packageInfo = require(path.join(__dirname, "package.json"));
-
-var binVersion = packageInfo.version;
-
-// 'arm', 'ia32', or 'x64'.
-var arch = process.arch;
-
-// 'darwin', 'freebsd', 'linux', 'sunos' or 'win32'
-var operatingSystem = process.platform;
-
-var filename = operatingSystem + "-" + arch + ".tar.gz";
-var url = "https://dl.bintray.com/elmlang/elm-format/default/" +
-  binVersion +
-  "/" +
-  filename;
+var url = require(path.join(__dirname, "elmFormatDownload.js")).url();
 
 var binariesDir = path.join(__dirname, "binaries");
 var packageInfo = require(path.join(__dirname, "package.json"));
@@ -24,8 +10,8 @@ var executablePaths = Object.keys(packageInfo.bin).map(function(executable) {
   return path.join(binariesDir, executable + binaryExtension);
 });
 var errorMessage = "Unfortunately, there are no elm-format " +
-  binVersion +
-  " binaries available on your operating system and architecture.\n\nIf you would like to build elm-format from source, there are instructions at https://github.com/avh4/elm-format#building-from-source\n";
+  packageInfo.version +
+  " binaries available for your operating system and architecture.\n\nIf you would like to build elm-format from source, there are instructions at https://github.com/avh4/elm-format#building-from-source\n";
 
 binstall(
   url,

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -3,8 +3,7 @@ var path = require("path");
 var fs = require("fs");
 var packageInfo = require(path.join(__dirname, "package.json"));
 
-// Use major.minor.patch from version string - e.g. "1.2.3" from "1.2.3-alpha"
-var binVersion = packageInfo.version.match(/^(\d+\.\d+\.\d+).*$/)[1];
+var binVersion = packageInfo.version;
 
 
 // 'arm', 'ia32', or 'x64'.
@@ -23,7 +22,7 @@ var binaryExtension = process.platform === "win32" ? ".exe" : "";
 var executablePaths = Object.keys(packageInfo.bin).map(function(executable) {
   return path.join(binariesDir, executable + binaryExtension);
 });
-var errorMessage = "Unfortunately, there are no elm-format " + binVersion + " binaries available on your operating system and architecture.\n\nIf you would like to build Elm from source, there are instructions at https://github.com/elm-lang/elm-platform#build-from-source\n";
+var errorMessage = "Unfortunately, there are no elm-format " + binVersion + " binaries available on your operating system and architecture.\n\nIf you would like to build elm-format from source, there are instructions at https://github.com/avh4/elm-format#building-from-source\n";
 
 binstall(url, {path: binariesDir},
   {verbose: true, verify: executablePaths, errorMessage: errorMessage}

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -5,7 +5,6 @@ var packageInfo = require(path.join(__dirname, "package.json"));
 
 var binVersion = packageInfo.version;
 
-
 // 'arm', 'ia32', or 'x64'.
 var arch = process.arch;
 
@@ -13,8 +12,10 @@ var arch = process.arch;
 var operatingSystem = process.platform;
 
 var filename = operatingSystem + "-" + arch + ".tar.gz";
-var url = "https://dl.bintray.com/elmlang/elm-format/default/"
-  + binVersion + "/" + filename;
+var url = "https://dl.bintray.com/elmlang/elm-format/default/" +
+  binVersion +
+  "/" +
+  filename;
 
 var binariesDir = path.join(__dirname, "binaries");
 var packageInfo = require(path.join(__dirname, "package.json"));
@@ -22,13 +23,20 @@ var binaryExtension = process.platform === "win32" ? ".exe" : "";
 var executablePaths = Object.keys(packageInfo.bin).map(function(executable) {
   return path.join(binariesDir, executable + binaryExtension);
 });
-var errorMessage = "Unfortunately, there are no elm-format " + binVersion + " binaries available on your operating system and architecture.\n\nIf you would like to build elm-format from source, there are instructions at https://github.com/avh4/elm-format#building-from-source\n";
+var errorMessage = "Unfortunately, there are no elm-format " +
+  binVersion +
+  " binaries available on your operating system and architecture.\n\nIf you would like to build elm-format from source, there are instructions at https://github.com/avh4/elm-format#building-from-source\n";
 
-binstall(url, {path: binariesDir},
-  {verbose: true, verify: executablePaths, errorMessage: errorMessage}
-).then(function(successMessage) {
+binstall(
+  url,
+  { path: binariesDir },
+  { verbose: true, verify: executablePaths, errorMessage: errorMessage }
+).then(
+  function(successMessage) {
     console.log(successMessage);
-  }, function(errorMessage) {
+  },
+  function(errorMessage) {
     console.error(errorMessage);
     process.exit(1);
-  });
+  }
+);

--- a/package/npm/install.js
+++ b/package/npm/install.js
@@ -1,6 +1,5 @@
 var binstall = require("binstall");
 var path = require("path");
-var fs = require("fs");
 var url = require(path.join(__dirname, "elmFormatDownload.js")).url();
 
 var binariesDir = path.join(__dirname, "binaries");

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -1,11 +1,13 @@
 {
   "name": "elm-format",
-  "version": "0.5.2-alpha-dev",
+  "version": "0.5.2",
   "description": "Install elm-format",
   "preferGlobal": true,
   "main": "install.js",
   "scripts": {
-    "install": "node install.js"
+    "install": "node install.js",
+    "prepublish": "npm test",
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -21,6 +23,7 @@
   },
   "files": [
     "install.js",
+    "elmFormatDownload.js",
     "binaries"
   ],
   "homepage": "https://github.com/avh4/elm-format",
@@ -29,5 +32,10 @@
   },
   "dependencies": {
     "binstall": "1.2.0"
+  },
+  "devDependencies": {
+    "mocha": "^3.2.0",
+    "request": "^2.81.0",
+    "request-promise": "^4.2.0"
   }
 }

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-format",
-  "version": "0.5.2",
+  "version": "0.5.2-alpha",
   "description": "Install elm-format",
   "preferGlobal": true,
   "main": "install.js",
@@ -35,7 +35,6 @@
   },
   "devDependencies": {
     "mocha": "^3.2.0",
-    "request": "^2.81.0",
-    "request-promise": "^4.2.0"
+    "then-request": "^2.2.0"
   }
 }

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -1,11 +1,11 @@
 {
   "name": "elm-format",
-  "version": "0.5.2",
+  "version": "0.5.2-alpha-dev",
   "description": "Install elm-format",
   "preferGlobal": true,
   "main": "install.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "install": "node install.js"
   },
   "repository": {
     "type": "git",
@@ -18,9 +18,6 @@
   "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/avh4/elm-format/issues"
-  },
-  "scripts": {
-    "install": "node install.js"
   },
   "files": [
     "install.js",

--- a/package/npm/package.json
+++ b/package/npm/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "install": "node install.js",
     "prepublish": "npm test",
-    "test": "mocha"
+    "test": "eslint . && mocha"
   },
   "repository": {
     "type": "git",
@@ -34,6 +34,7 @@
     "binstall": "1.2.0"
   },
   "devDependencies": {
+    "eslint": "^3.18.0",
     "mocha": "^3.2.0",
     "then-request": "^2.2.0"
   }

--- a/package/npm/test/publishedBinariesSpec.js
+++ b/package/npm/test/publishedBinariesSpec.js
@@ -1,0 +1,25 @@
+var request = require("request-promise");
+var elmFormat = require("../elmFormatDownload");
+
+function showUrl(url) {
+  return function(error) {
+    return Promise.reject(url + ": " + error);
+  };
+}
+
+function checkBinary(os, arch) {
+  return function() {
+    var url = elmFormat.url(os, arch);
+    return request.head(url).catch(showUrl(url));
+  };
+}
+
+describe("published binaries", function() {
+  it("(tests should be able to connect to the internet)", function() {
+    return request.head("https://google.com");
+  });
+
+  it("should include Mac binaries", checkBinary("darwin", "x64"));
+  it("should include Linux binaries", checkBinary("linux", "x64"));
+  it("should include Windows binaries", checkBinary("win32", "x64"));
+});

--- a/package/npm/test/publishedBinariesSpec.js
+++ b/package/npm/test/publishedBinariesSpec.js
@@ -1,4 +1,4 @@
-var request = require("request-promise");
+var request = require("then-request");
 var elmFormat = require("../elmFormatDownload");
 
 function showUrl(url) {
@@ -10,13 +10,13 @@ function showUrl(url) {
 function checkBinary(os, arch) {
   return function() {
     var url = elmFormat.url(os, arch);
-    return request.head(url).catch(showUrl(url));
+    return request("HEAD", url).catch(showUrl(url));
   };
 }
 
 describe("published binaries", function() {
   it("(tests should be able to connect to the internet)", function() {
-    return request.head("https://google.com");
+    return request("HEAD", "https://google.com");
   });
 
   it("should include Mac binaries", checkBinary("darwin", "x64"));


### PR DESCRIPTION
To try it out: (this will install `elm-format 0.5.2-alpha` for Elm 0.18)

```
$ npm install -g /path/to/elm-format/package/npm
$ elm-format --version
```

Should work on the 64-bit versions of:

* macOS
* Linux
* Windows

## Notes

It installs `elm-format` versions based on the `version` specified in `package.json`, which is set up to include both the `elm-format` version and the Elm version.

For example, to explicitly get the latest version, you'd run `npm install -g elm-format@0.5.2-elm0.18.0` (although in the case of the absolute latest version you could always just do `npm install -g elm-format`)

This means when publishing a new version, you'd need to publish all the combinations as separate npm package releases.

## TODO

Add CI tests like what `elm-platform` uses, to verify all the combinations download and install successfully.