### PR TITLE
Make indentation configurable via --tabsize; closes #210

### DIFF
--- a/parser/src/Reporting/Report.hs
+++ b/parser/src/Reporting/Report.hs
@@ -18,6 +18,7 @@ import System.IO (hPutStr, stderr)
 
 import qualified Reporting.Region as R
 
+import Defaults
 
 data Report = Report
     { _title :: String
@@ -121,7 +122,7 @@ ansi tipe =
 messageBar :: Renderer m -> String -> String -> m ()
 messageBar renderer tag location =
   let
-    usedSpace = 4 + length tag + 1 + length location
+    usedSpace = defaultTabSize + length tag + 1 + length location
   in
     header renderer $
       "-- " ++ tag ++ " "

--- a/src/Defaults.hs
+++ b/src/Defaults.hs
@@ -1,0 +1,7 @@
+{-# OPTIONS_GHC -Wall #-}
+module Defaults where
+
+
+-- See: https://github.com/avh4/elm-format/issues/210
+defaultTabSize :: Int
+defaultTabSize = 4

--- a/src/ElmFormat/Render/ElmStructure.hs
+++ b/src/ElmFormat/Render/ElmStructure.hs
@@ -142,8 +142,8 @@ application forceMultiline first args =
     ; child2
     >
 -}
-group :: Bool -> String -> String -> String -> Bool -> [Box] -> Box
-group innerSpaces left sep right forceMultiline children =
+group :: Int -> Bool -> String -> String -> String -> Bool -> [Box] -> Box
+group tabsize innerSpaces left sep right forceMultiline children =
   case (forceMultiline, allSingles children) of
     (_, Right []) ->
       line $ row [punc left, punc right]
@@ -162,8 +162,8 @@ group innerSpaces left sep right forceMultiline children =
 
         (first:rest) ->
           stack1 $
-            (prefix (row [punc left, space]) first)
-            : (map (prefix $ row [punc sep, space]) rest)
+            (prefix tabsize (row [punc left, space]) first)
+            : (map (prefix tabsize $ row [punc sep, space]) rest)
             ++ [ line $ punc right ]
 
 {-|
@@ -179,8 +179,8 @@ Formats as:
       , rest1
     }
 -}
-extensionGroup :: Bool -> Box -> Box -> [Box] -> Box
-extensionGroup multiline base first rest =
+extensionGroup :: Int -> Bool -> Box -> Box -> [Box] -> Box
+extensionGroup tabSize multiline base first rest =
   case
     ( multiline
     , isLine base
@@ -202,10 +202,10 @@ extensionGroup multiline base first rest =
 
     _ ->
       stack1
-        [ prefix (row [punc "{", space]) base
+        [ prefix tabSize (row [punc "{", space]) base
         , stack1
-            ([ prefix (row [punc "|", space]) first ]
-            ++ (map (prefix (row [punc ",", space])) rest))
+            ([ prefix tabSize (row [punc "|", space]) first ]
+            ++ (map (prefix tabSize (row [punc ",", space])) rest))
             |> indent
         , line $ punc "}"
         ]

--- a/src/ElmFormat/Render/Text.hs
+++ b/src/ElmFormat/Render/Text.hs
@@ -10,8 +10,8 @@ import qualified Data.Text as Text
 import qualified ElmFormat.Render.Box as Render
 
 
-render :: ElmVersion -> AST.Module.Module -> Text.Text
-render elmVersion modu =
+render :: ElmVersion -> Int -> AST.Module.Module -> Text.Text
+render elmVersion tabSize modu =
     let
         trimSpaces text =
             text
@@ -19,6 +19,6 @@ render elmVersion modu =
                 |> map Text.stripEnd
                 |> Text.unlines
     in
-        Render.formatModule elmVersion modu
-            |> Box.render
+        Render.formatModule elmVersion tabSize modu
+            |> Box.render tabSize
             |> trimSpaces

--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -4,6 +4,7 @@ module Flags where
 import Data.Monoid ((<>))
 import Data.Version (showVersion)
 import ElmVersion (ElmVersion(..))
+import Defaults
 
 import qualified Data.Maybe as Maybe
 import qualified ElmVersion
@@ -18,6 +19,7 @@ data Config = Config
     , _yes :: Bool
     , _validate :: Bool
     , _stdin :: Bool
+    , _tabSize :: Int
     , _elmVersion :: ElmVersion
     , _upgrade :: Bool
     }
@@ -85,6 +87,7 @@ flags defaultVersion =
       <*> yes
       <*> validate
       <*> stdin
+      <*> tabSize
       <*> elmVersion defaultVersion
       <*> upgrade
 
@@ -166,6 +169,17 @@ stdin =
         mconcat
         [ Opt.long "stdin"
         , Opt.help "Read from stdin, output to stdout."
+        ]
+
+tabSize :: Opt.Parser Int
+tabSize =
+    -- Opt.optional $
+    Opt.option Opt.auto $
+        mconcat
+        [ Opt.long "tabsize"
+        , Opt.metavar "SPACES"
+        , Opt.value defaultTabSize
+        , Opt.help $ "Spaces per tab (default: " ++ show defaultTabSize ++ ")"
         ]
 
 

--- a/tests/BoxTest.hs
+++ b/tests/BoxTest.hs
@@ -8,6 +8,7 @@ import qualified Data.Text.Lazy as LazyText
 import qualified Data.Text as Text
 
 import Box
+import Defaults
 
 
 trim :: String -> String
@@ -28,7 +29,7 @@ assertLineOutput expected actual =
 assertOutput :: String -> Box -> Assertion
 assertOutput expected actual =
     assertEqual expected expected $
-        trim $ Text.unpack $ render $ actual
+        trim $ Text.unpack $ render defaultTabSize $ actual
 
 
 word :: String -> Box
@@ -74,5 +75,5 @@ tests =
                 ]
     , testCase "indent (with leading spaces)" $
         assertOutput "    a\n" $
-            prefix space $ indent $ line $ identifier "a"
+            prefix defaultTabSize space $ indent $ line $ identifier "a"
     ]

--- a/tests/ElmFormat/CliTest/Usage.stdout
+++ b/tests/ElmFormat/CliTest/Usage.stdout
@@ -1,7 +1,7 @@
 elm-format-0.18 0.5.2-alpha
 
 Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
-                  [--elm-version VERSION] [--upgrade]
+                  [--tabsize SPACES] [--elm-version VERSION] [--upgrade]
   Format Elm source files.
 
 Available options:
@@ -11,6 +11,7 @@ Available options:
   --yes                    Reply 'yes' to all automated prompts.
   --validate               Check if files are formatted without changing them.
   --stdin                  Read from stdin, output to stdout.
+  --tabsize SPACES         Spaces per tab (default: 4)
   --elm-version VERSION    The Elm version of the source files being formatted.
                            Valid values: 0.16, 0.17, 0.18. Default: 0.18
   --upgrade                Upgrade older Elm files to Elm 0.18 syntax

--- a/tests/ElmFormat/Render/ElmStructureTest.hs
+++ b/tests/ElmFormat/Render/ElmStructureTest.hs
@@ -10,6 +10,7 @@ import qualified Data.Text as Text
 import AST.V0_16
 import Box
 import ElmFormat.Render.ElmStructure
+import Defaults
 
 
 trim :: String -> String
@@ -30,7 +31,7 @@ assertLineOutput expected actual =
 assertOutput :: String -> Box -> Assertion
 assertOutput expected actual =
     assertEqual expected expected $
-        trim $ Text.unpack $ render $ actual
+        trim $ Text.unpack $ render defaultTabSize $ actual
 
 
 word :: String -> Box
@@ -72,20 +73,20 @@ tests =
                 ]
     , testCase "group (empty)" $
         assertOutput "()\n" $
-            group True "(" "," ")" False []
+            group defaultTabSize True "(" "," ")" False []
     , testCase "group (single item, single line)" $
         assertOutput "( foo )\n" $
-            group True "(" "," ")" False [ word "foo" ]
+            group defaultTabSize True "(" "," ")" False [ word "foo" ]
     , testCase "group (single line)" $
         assertOutput "( foo, bar )\n" $
-            group True "(" "," ")" False [ word "foo", word "bar" ]
+            group defaultTabSize True "(" "," ")" False [ word "foo", word "bar" ]
     , testCase "group (single line, no spaces)" $
         assertOutput "(foo, bar)\n" $
-            group False "(" "," ")" False [ word "foo", word "bar" ]
+            group defaultTabSize False "(" "," ")" False [ word "foo", word "bar" ]
     , testCase "group (multiline)" $
         assertOutput "( aa\n  aa\n, b\n, cc\n  cc\n)\n" $
-            group True "(" "," ")" False [ block "a", word "b", block "c" ]
+            group defaultTabSize True "(" "," ")" False [ block "a", word "b", block "c" ]
     , testCase "group (forced multiline)" $
         assertOutput "( a\n, b\n, c\n)\n" $
-            group True "(" "," ")" True [ word "a", word "b", word "c" ]
+            group defaultTabSize True "(" "," ")" True [ word "a", word "b", word "c" ]
     ]

--- a/tests/Test/Property.hs
+++ b/tests/Test/Property.hs
@@ -21,7 +21,7 @@ import qualified ElmFormat.Render.Text as Render
 import qualified ElmVersion
 import qualified Test.Generators
 import qualified Test.ElmSourceGenerators
-
+import qualified Defaults
 
 assertStringToString :: String -> Assertion
 assertStringToString source =
@@ -31,7 +31,7 @@ assertStringToString source =
         result =
             Parse.parse source'
                 |> Parse.toEither
-                |> fmap (Render.render ElmVersion.Elm_0_17)
+                |> fmap (Render.render ElmVersion.Elm_0_17 Defaults.defaultTabSize)
     in
         assertEqual "" (Right source') result
 
@@ -41,7 +41,7 @@ astToAst ast =
     let
         result =
             ast
-                |> Render.render ElmVersion.Elm_0_17
+                |> Render.render ElmVersion.Elm_0_17 Defaults.defaultTabSize
                 |> Parse.parse
                 |> Parse.toEither
     in
@@ -57,9 +57,9 @@ simpleAst =
 
 reportFailedAst ast =
     let
-        rendering = Render.render ElmVersion.Elm_0_17 ast |> Text.unpack
+        rendering = Render.render ElmVersion.Elm_0_17 Defaults.defaultTabSize ast |> Text.unpack
         result =
-            Render.render ElmVersion.Elm_0_17 ast
+            Render.render ElmVersion.Elm_0_17 Defaults.defaultTabSize ast
                 |> Parse.parse
                 |> fmap stripRegion
                 |> show


### PR DESCRIPTION
The number of spaces that constitute a tab of indentation in the output code is now configurable via the `--tabsize` command line argument.  Changing the value from a constant to a configurable parameter meant that I had to thread it all the way from the entry point into every function that is affected by the tab size.

Now that it's done, making another deeply permeating value configurable will simply mean converting the `tabSize` parameter to a record containing more than one member.

This is my first time touching this code, so please give it a careful look over.