### PR TITLE
Clarify atom installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ Find your editor in the table below.  The recommended plugin for each editor is 
   </tr>
   <tr>
     <td rowspan=2><a href="https://atom.io/">Atom</a></td>
-    <td>:trophy: <a href="https://atom.io/packages/elm-format">atom-elm-format</a></td>
-    <td>:white_check_mark: <a href="#atom-elm-format-installation">2 steps</a></td>
+    <td>:trophy: <a href="https://atom.io/packages/elm-format">elm-format</a></td>
+    <td>:white_check_mark: <a href="#atom-installation">2 steps</a></td>
     <td>:warning: must use format-on-save or save file before formatting</td>
     <td>:white_check_mark:</td>
     <td>:white_check_mark:</td>
@@ -159,30 +159,29 @@ If you can simplify or improve the installation instructions or add instructions
 The default behavior of `elm-format`-approved plugins is to format Elm files on save.
 
 
-### atom-elm-format installation
+### Atom installation
 
+##### Pre-install:
+1. Download the appropriate elm-format binary
+2. Moving it to `usr/local/bin` will save some time later, although you can technically place it anywhere in your file system.
+
+##### Install:
 1. Install elm-format
-1. Install atom-elm-format
+2. Install atom-beautify
+```
+$ apm install elm-format
+$ apm install atom-beautify
+```
 
-    ```
-    apm install elm-format
-    ```
+or, use the Atom package manager in Atom's settings
 
-  or use the Atom package manager in Atom's settings
+##### Post-Install:
+1. Locate the elm-format binary
+2. From Settings -> Package -> elm-format, add binary's path
 
-
-### atom-beautify installation
-
-1. Install elm-format
-1. Install atom-beautify
-
-    ```
-    apm install atom-beautify
-    ```
-
-  or use the Atom package manager in Atom's settings
-
-1. Use `^⌥B` (`CTRL-ALT-B`) to format a file
+##### Usage:
+1. Format-on-save is enabled by default
+2. Use `^⌥B` (`CTRL-ALT-B`) to format a file (optional) 
 
 
 ### elm-light installation


### PR DESCRIPTION
This is a discussion-seeking PR. Following these instructions helped me get elm-format working but this process could benefit from other users' feedback.

I chose to rename references to the `elm-format` package since there's not a published package called `atom-elm-format` on apm.