### PR TITLE
--validate outputs a valid JSON array

### DIFF
--- a/src/ElmFormat/Execute.hs
+++ b/src/ElmFormat/Execute.hs
@@ -1,9 +1,10 @@
-module ElmFormat.Execute (forHuman, forMachine) where
+module ElmFormat.Execute (forHuman, forMachine, forMachineInit, forMachineDone) where
 
 {-| This module provides executors that can take streams of Operations and
 perform IO.
 -}
 
+import Control.Monad.State
 import ElmFormat.Operation
 import ElmVersion
 
@@ -22,9 +23,19 @@ forHuman operation =
 
 
 {-| Execute Operations in a fashion appropriate for use by automated scripts. -}
-forMachine :: ElmVersion -> OperationF a -> IO a
+forMachine :: ElmVersion -> OperationF a -> StateT Bool IO a
 forMachine elmVersion operation =
     case operation of
-        InFileStore op -> FileStore.execute op
+        InFileStore op -> lift $ FileStore.execute op
         InInfoFormatter op -> Json.format elmVersion op
-        DeprecatedIO io -> io
+        DeprecatedIO io -> lift io
+
+
+forMachineInit :: (IO (), Bool)
+forMachineInit =
+    Json.init
+
+
+forMachineDone :: IO ()
+forMachineDone =
+    Json.done

--- a/tests/json-format-schema.json
+++ b/tests/json-format-schema.json
@@ -1,18 +1,21 @@
 {
-  "type": "object",
-  "properties": {
-    "path": {
-      "type": "string"
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "path": {
+        "type": "string"
+      },
+      "line": {
+        "type": "number"
+      },
+      "column": {
+        "type": "number"
+      },
+      "message": {
+        "type": "string"
+      }
     },
-    "line": {
-      "type": "number"
-    },
-    "column": {
-      "type": "number"
-    },
-    "message": {
-      "type": "string"
-    }
-  },
-  "required": ["path", "message"]
+    "required": ["path", "message"]
+  }
 }

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -250,24 +250,21 @@ function checkValidationOutputFormat() {
 	echo "# VALIDATION OUTPUT IN JSON"
 	echo
 
-	echo "## with unformatted files outputs in expected json format line by line"
-	"$ELM_FORMAT" "$INPUT" "$INPUT_2" --validate | \
-	while read -r line; do
-		echo "$line" | tee "$STDOUT"; ajv test -s tests/json-format-schema.json -d "$STDOUT" --valid
-	done <&0
+	echo "## with unformatted files outputs in expected json format"
+	"$ELM_FORMAT" "$INPUT" "$INPUT_2" --validate > "$STDOUT"
+	ajv test -s tests/json-format-schema.json -d "$STDOUT" --valid
 	returnCodeShouldEqual 0
 
-	echo "## with invalid files outputs in expected json format line by line"
-	"$ELM_FORMAT" "tests/test-files/bad/Empty.elm" --validate | \
-	while read -r line; do
-		echo "$line" | tee "$STDOUT"; ajv test -s tests/json-format-schema.json -d "$STDOUT" --valid
-	done <&0
+	echo "## with invalid files outputs in expected json format"
+	"$ELM_FORMAT" "tests/test-files/bad/Empty.elm" --validate > "$STDOUT"
+	ajv test -s tests/json-format-schema.json -d "$STDOUT" --valid
 	returnCodeShouldEqual 0
 
-	echo "## with formatted file with output in json outputs nothing"
+	echo "## with formatted file with output in json outputs empty list"
 	"$ELM_FORMAT" "$INPUT" "$INPUT_2" --yes 1>/dev/null
 	"$ELM_FORMAT" "$INPUT" "$INPUT_2" --validate 1>"$STDOUT"
-	[ ! -s "$STDOUT" ] || exit 1
+	grep -q "^\[\]$" "$STDOUT"
+	returnCodeShouldEqual 0
 
 	echo "# OK!"
 	echo "------------------------------"


### PR DESCRIPTION
@ento this is the final step for https://github.com/avh4/elm-format/pull/316, and makes it output a valid JSON array with square brackets and commas.

(note: depends on #317, which I will merge, along with #316 if this PR looks good.)