### PR TITLE
Add gpg steps to Arch linux packaging guide.

### DIFF
--- a/package/linux/archlinux/.gitignore
+++ b/package/linux/archlinux/.gitignore
@@ -1,3 +1,4 @@
 .vagrant
 elm-format-0.16-bin
 elm-format-0.17-bin
+elm-format-0.18-bin

--- a/package/linux/archlinux/README.md
+++ b/package/linux/archlinux/README.md
@@ -28,6 +28,9 @@ vagrant up
 vagrant ssh
 cd /vagrant/elm-format-0.18-bin
 
+# Ensure you have @avh4's PGP key:
+curl https://keybase.io/avh4/pgp_keys.asc | gpg --import
+
 # Generate checksums:
 makepkg -g
 


### PR DESCRIPTION
The Arch packages now validate the PGP signatures, so users need to import your key.