### PR TITLE
Remove hiding and foreign from reserved words list

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,6 +7,7 @@ Copyright (c) 2016, Max Goldstein
 Copyright (c) 2016, Daniel Bachler
 Copyright (c) 2016, Fedor Nezhivoi
 Copyright (c) 2013, John MacFarlane (Markdown parser forked from jgm/cheapskate)
+Copyright (c) 2017, Michael Maloney
 
 All rights reserved.
 

--- a/parser/src/Parse/Helpers.hs
+++ b/parser/src/Parse/Helpers.hs
@@ -29,11 +29,10 @@ reserveds =
     , "let", "in"
     , "type"
     , "module", "where"
-    , "import", "as", "hiding", "exposing"
-    , "port", "foreign"
-    , "deriving"
+    , "import", "exposing"
+    , "as"
+    , "port"
     ]
-
 
 -- ERROR HELP
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -303,6 +303,7 @@ checkGoodAllSyntax 0.16 Module
 checkGood 0.18 AllSyntax/0.18/Declarations.elm
 checkGoodAllSyntax 0.18 Patterns
 checkGoodAllSyntax 0.18 Types
+checkGood 0.18 AllSyntax/0.18/OldKeywords.elm
 checkGood 0.18 AllSyntax/0.18/Expressions.elm
 checkGood 0.18 AllSyntax/0.18/Expressions/Unary.elm
 checkGood 0.18 AllSyntax/0.18/Expressions/BinaryOperators.elm
@@ -322,6 +323,7 @@ checkGood 0.16 AllSyntax/0.16/Range.elm
 
 checkGood 0.17 AllSyntax/0.17/Range.elm
 checkGood 0.17 AllSyntax/0.17/InfixOperators.elm
+checkGood 0.17 AllSyntax/0.17/OldKeywords.elm
 checkGood 0.17 Export.elm
 checkGoodAllSyntax 0.17 Module
 checkGoodAllSyntax 0.17 ModuleEffect

--- a/tests/test-files/good/AllSyntax/0.17/OldKeywords.elm
+++ b/tests/test-files/good/AllSyntax/0.17/OldKeywords.elm
@@ -1,0 +1,23 @@
+module AllSyntax.OldKeywords exposing (..)
+
+
+type alias OldKeywords =
+    { foreign : Int
+    , hiding : Bool
+    , deriving : String
+    }
+
+
+foreign : Float
+foreign =
+    0
+
+
+hiding : Int -> Int
+hiding x =
+    x + 1
+
+
+deriving : Maybe OldKeywords
+deriving =
+    Nothing

--- a/tests/test-files/good/AllSyntax/0.18/OldKeywords.elm
+++ b/tests/test-files/good/AllSyntax/0.18/OldKeywords.elm
@@ -1,0 +1,23 @@
+module AllSyntax.OldKeywords exposing (..)
+
+
+type alias OldKeywords =
+    { foreign : Int
+    , hiding : Bool
+    , deriving : String
+    }
+
+
+foreign : Float
+foreign =
+    0
+
+
+hiding : Int -> Int
+hiding x =
+    x + 1
+
+
+deriving : Maybe OldKeywords
+deriving =
+    Nothing


### PR DESCRIPTION
I managed to break elm-format by naming one of my variables `hiding` earlier today. After tracking it down, I found that elm-format includes `hiding`, `foreign`, and `deriving` as reserved words (carry-overs from Haskell?) which are not keywords in (the current version of) Elm. 

I changed the keyword list to match [the keyword list in elm-compiler](https://github.com/elm-lang/elm-compiler/blob/master/src/Parse/Primitives.hs#L364-L375)

Cheers.