### PR TITLE
Fix some compiler warnings

### DIFF
--- a/markdown/Cheapskate/Inlines.hs
+++ b/markdown/Cheapskate/Inlines.hs
@@ -15,7 +15,6 @@ import Prelude hiding (takeWhile)
 import Control.Applicative
 import Data.Monoid
 import Control.Monad
-import qualified Data.Map as M
 import Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Set as Set
@@ -351,11 +350,6 @@ pInlineLink lab = do
   tit <- option "" $ scanSpnl *> pLinkTitle <* scanSpaces
   char ')'
   return $ singleton $ Link lab (Url url) tit
-
-lookupLinkReference :: ReferenceMap
-                    -> Text                -- reference label
-                    -> Maybe (Text, Text)  -- (url, title)
-lookupLinkReference refmap key = M.lookup (normalizeReference key) refmap
 
 -- A reference link: [label], [foo][label], or [label][].
 pReferenceLink :: ReferenceMap -> Text -> Inlines -> Parser Inlines

--- a/markdown/Cheapskate/Inlines.hs
+++ b/markdown/Cheapskate/Inlines.hs
@@ -22,7 +22,7 @@ import qualified Data.Set as Set
 -- Returns tag type and whole tag.
 pHtmlTag :: Parser (HtmlTagType, Text)
 pHtmlTag = do
-  char '<'
+  _ <- char '<'
   -- do not end the tag with a > character in a quoted attribute.
   closing <- (char '/' >> return True) <|> return False
   tagname <- takeWhile1 (\c -> isAsciiAlphaNum c || c == '?' || c == '!')
@@ -36,7 +36,7 @@ pHtmlTag = do
                 return $ ss <> T.singleton x <> xs <> "=" <> v
   attrs <- T.concat <$> many attr
   final <- takeWhile (\c -> isSpace c || c == '/')
-  char '>'
+  _ <- char '>'
   let tagtype = if closing
                    then Closing tagname'
                    else case T.stripSuffix "/" final of
@@ -57,7 +57,7 @@ pQuoted c = do
 -- do for now.
 pHtmlComment :: Parser Text
 pHtmlComment = do
-  string "<!--"
+  _ <- string "<!--"
   rest <- manyTill anyChar (string "-->")
   return $ "<!--" <> T.pack rest <> "-->"
 
@@ -118,7 +118,7 @@ pLinkTitle = do
 pReference :: Parser (Text, Text, Text)
 pReference = do
   lab <- pLinkLabel
-  char ':'
+  _ <- char ':'
   scanSpnl
   url <- pLinkUrl
   tit <- option T.empty $ scanSpnl >> pLinkTitle
@@ -239,7 +239,7 @@ schemeSet = Set.fromList $ schemes ++ map T.toUpper schemes
 -- Parse a URI, using heuristics to avoid capturing final punctuation.
 pUri :: Text -> Parser Inlines
 pUri scheme = do
-  char ':'
+  _ <- char ':'
   x <- scan (OpenParens 0) uriScanner
   guard $ not $ T.null x
   let (rawuri, endingpunct) =
@@ -344,11 +344,11 @@ pLink refmap = do
 -- An inline link: [label](/url "optional title")
 pInlineLink :: Inlines -> Parser Inlines
 pInlineLink lab = do
-  char '('
+  _ <- char '('
   scanSpaces
   url <- pLinkUrl
   tit <- option "" $ scanSpnl *> pLinkTitle <* scanSpaces
-  char ')'
+  _ <- char ')'
   return $ singleton $ Link lab (Url url) tit
 
 -- A reference link: [label], [foo][label], or [label][].
@@ -361,7 +361,7 @@ pReferenceLink _ rawlab lab = do
 -- An image:  ! followed by a link.
 pImage :: ReferenceMap -> Parser Inlines
 pImage refmap = do
-  char '!'
+  _ <- char '!'
   (linkToImage <$> pLink refmap) <|> return (singleton (Str "!"))
 
 linkToImage :: Inlines -> Inlines
@@ -377,9 +377,9 @@ linkToImage ils =
 -- convert them to characters and store them as Str inlines.
 pEntity :: Parser Inlines
 pEntity = do
-  char '&'
+  _ <- char '&'
   res <- pCharEntity <|> pDecEntity <|> pHexEntity
-  char ';'
+  _ <- char ';'
   return $ singleton $ Entity $ "&" <> res <> ";"
 
 pCharEntity :: Parser Text
@@ -387,13 +387,13 @@ pCharEntity = takeWhile1 (\c -> isAscii c && isLetter c)
 
 pDecEntity :: Parser Text
 pDecEntity = do
-  char '#'
+  _ <- char '#'
   res <- takeWhile1 isDigit
   return $ "#" <> res
 
 pHexEntity :: Parser Text
 pHexEntity = do
-  char '#'
+  _ <- char '#'
   x <- char 'X' <|> char 'x'
   res <- takeWhile1 isHexDigit
   return $ "#" <> T.singleton x <> res

--- a/markdown/Cheapskate/Parse.hs
+++ b/markdown/Cheapskate/Parse.hs
@@ -116,7 +116,7 @@ containerContinue c =
                          <|>
                          (do scanSpacesToColumn
                                 (markerColumn li + 1)
-                             upToCountChars (padding li - 1)
+                             _ <- upToCountChars (padding li - 1)
                                 (==' ')
                              return ())
        Reference{}    -> nfb scanBlankline >>
@@ -450,7 +450,7 @@ processLine (lineNumber, txt) = do
        -- otherwise, close all the unmatched containers, add the new
        -- containers, and finally add the new leaf:
        (ns, lf) -> do -- close unmatched containers, add new ones
-           replicateM numUnmatched closeContainer
+           _ <- replicateM numUnmatched closeContainer
            addNew (ns, lf)
 
   where
@@ -531,7 +531,7 @@ scanBlockquoteStart = scanChar '>' >> option () (scanChar ' ')
 -- a header.
 parseAtxHeaderStart :: Parser Int
 parseAtxHeaderStart = do
-  char '#'
+  _ <- char '#'
   hashes <- upToCountChars 5 (== '#')
   -- hashes must be followed by space unless empty header:
   notFollowedBy (skip (/= ' '))
@@ -551,7 +551,7 @@ parseSetextHeaderLine = do
 scanHRuleLine :: Scanner
 scanHRuleLine = do
   c <- satisfy (\c -> c == '*' || c == '_' || c == '-')
-  count 2 $ scanSpaces >> skip (== c)
+  _ <- count 2 $ scanSpaces >> skip (== c)
   skipWhile (\x -> x == ' ' || x == c)
   endOfInput
 

--- a/markdown/Cheapskate/Util.hs
+++ b/markdown/Cheapskate/Util.hs
@@ -21,7 +21,7 @@ module Cheapskate.Util (
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Char
-import Control.Applicative
+import Control.Applicative ()
 import Cheapskate.ParserCombinators
 
 -- Utility functions.

--- a/parser/src/Parse/Helpers.hs
+++ b/parser/src/Parse/Helpers.hs
@@ -465,7 +465,7 @@ accessible :: IParser AST.Expression.Expr -> IParser AST.Expression.Expr
 accessible exprParser =
   do  start <- getMyPosition
 
-      annotatedRootExpr@(A.A _ rootExpr) <- exprParser
+      annotatedRootExpr@(A.A _ _rootExpr) <- exprParser
 
       access <- optionMaybe (try dot <?> "a field access like .name")
 

--- a/parser/src/Parse/Helpers.hs
+++ b/parser/src/Parse/Helpers.hs
@@ -507,7 +507,7 @@ failure :: String -> IParser String
 failure msg = do
   inp <- getInput
   setInput ('x':inp)
-  anyToken
+  _ <- anyToken
   fail msg
 
 

--- a/parser/src/Parse/Module.hs
+++ b/parser/src/Parse/Module.hs
@@ -234,8 +234,8 @@ mergeListing merge left right =
         (Var.OpenListing (Commented pre1 () post1), Var.OpenListing (Commented pre2 () post2)) -> Var.OpenListing (Commented (pre1 ++ pre2) () (post1 ++ post2))
         (Var.ClosedListing, Var.ExplicitListing a multiline) -> Var.ExplicitListing a multiline
         (Var.ExplicitListing a multiline, Var.ClosedListing) -> Var.ExplicitListing a multiline
-        (Var.OpenListing comments, Var.ExplicitListing a multiline) -> Var.OpenListing comments
-        (Var.ExplicitListing a multiline, Var.OpenListing comments) -> Var.OpenListing comments
+        (Var.OpenListing comments, Var.ExplicitListing _a _multiline) -> Var.OpenListing comments
+        (Var.ExplicitListing _a _multiline, Var.OpenListing comments) -> Var.OpenListing comments
         (Var.ExplicitListing a multiline1, Var.ExplicitListing b multiline2) -> Var.ExplicitListing (merge a b) (multiline1 || multiline2)
 
 

--- a/parser/src/Reporting/Error/Syntax.hs
+++ b/parser/src/Reporting/Error/Syntax.hs
@@ -45,8 +45,8 @@ toReport err =
       where
         operator =
             case op of
-              Var.VarRef namespace (LowercaseIdentifier name) -> "`" ++ name ++ "`"
-              Var.TagRef namespace (UppercaseIdentifier name) -> "`" ++ name ++ "`"
+              Var.VarRef _namespace (LowercaseIdentifier name) -> "`" ++ name ++ "`"
+              Var.TagRef _namespace (UppercaseIdentifier name) -> "`" ++ name ++ "`"
               Var.OpRef (SymbolIdentifier name) -> "(" ++ name ++ ")"
 
     TypeWithoutDefinition valueName ->

--- a/src/ElmFormat/Render/Box.hs
+++ b/src/ElmFormat/Render/Box.hs
@@ -144,7 +144,7 @@ declarationType decl =
         AST.Declaration.PortAnnotation (Commented _ name _) _ _ ->
           DDefinition $ Just $ AST.Variable.VarRef [] name
 
-        AST.Declaration.Fixity _ _ _ _ name ->
+        AST.Declaration.Fixity _ _ _ _ _name ->
           DFixity
 
     AST.Declaration.DocComment _ ->

--- a/src/ElmFormat/Render/Markdown.hs
+++ b/src/ElmFormat/Render/Markdown.hs
@@ -37,7 +37,7 @@ formatMarkdown formatCode blocks =
 
 
 mapWithPrev :: (Maybe a -> a -> b) -> [a] -> [b]
-mapWithPrev f [] = []
+mapWithPrev _ [] = []
 mapWithPrev f (first:rest) =
     f Nothing first : zipWith (\prev next -> f (Just prev) next) (first:rest) rest
 
@@ -88,7 +88,7 @@ formatMardownBlock formatCode context block =
             fold $ (if tight then id else List.intersperse "\n") $
                 fmap (formatListItem formatCode) $ zip [1..] items
 
-        CodeBlock (CodeAttr lang info) code ->
+        CodeBlock (CodeAttr lang _info) code ->
             let
                 formatted =
                     fromMaybe (Text.unpack $ ensureNewline code) $ formatCode $ Text.unpack code


### PR DESCRIPTION
Fix compiler warnings of the following types:
 - `unused-imports`
 - `unused-top-binds`
 - `unused-matches`
 - `unused-do-binds `

Progress on #302 

@avh4 I know you suggested doing PRs for one file at a time, but this is what I had done so far, and it seemed easy enough to reason about, so I figured I'd make a PR with it before continuing. I can do a PR per file from now on or continue with one per compiler warning? (Or even build on this one, I think the total amount of compiler warnings was ~ 30, so the final diff wouldn't be that hard to consume, especially if doing so in commit-increments). It's up to you 😊

Also, let me know if something looks off or should be done differently. Like I said, not a long time Haskeller, and I couldn't find a style guide.