### PR TITLE
cleanup imports

### DIFF
--- a/parser/src/Reporting/Report.hs
+++ b/parser/src/Reporting/Report.hs
@@ -11,7 +11,6 @@ import Control.Applicative ((<|>))
 import Control.Monad.Writer (Writer, execWriter, tell)
 import qualified Data.List.Split as Split
 import System.Console.ANSI
-import System.IO (hPutStr, stderr)
 import ElmFormat.World
 
 import qualified Reporting.Region as R

--- a/src/ElmFormat.hs
+++ b/src/ElmFormat.hs
@@ -3,9 +3,8 @@ module ElmFormat where
 
 import Prelude hiding (putStr, putStrLn)
 
-import System.Exit (ExitCode(..), exitWith)
+import System.Exit (ExitCode(..))
 import System.Environment (getArgs)
-import System.IO (hPutStrLn, stderr)
 import Messages.Types
 import Messages.Formatter.Format
 import Control.Monad.Free
@@ -14,7 +13,6 @@ import ElmVersion
 import ElmFormat.FileStore (FileStore)
 import ElmFormat.FileWriter (FileWriter)
 import ElmFormat.InputConsole (InputConsole)
-import ElmFormat.Operation (Operation)
 import ElmFormat.OutputConsole (OutputConsole)
 import ElmFormat.World
 

--- a/src/ElmFormat/FileStore.hs
+++ b/src/ElmFormat/FileStore.hs
@@ -4,8 +4,6 @@ import Prelude hiding (readFile, writeFile)
 import Control.Monad.Free
 import Data.Text (Text)
 import ElmFormat.World hiding (readFile, listDirectory)
-import qualified Data.ByteString as ByteString
-import qualified Data.Text.Encoding as Text
 import qualified ElmFormat.World as World
 
 

--- a/src/ElmFormat/FileWriter.hs
+++ b/src/ElmFormat/FileWriter.hs
@@ -1,13 +1,9 @@
 module ElmFormat.FileWriter (FileWriter, FileWriterF(..), writeFile, overwriteFile, execute) where
 
-import qualified System.Directory as Dir
-
 import Prelude hiding (writeFile)
 import Control.Monad.Free
 import Data.Text (Text)
 import ElmFormat.World (World)
-import qualified Data.ByteString as ByteString
-import qualified Data.Text.Encoding as Text
 import qualified ElmFormat.World as World
 
 

--- a/src/ElmFormat/InputConsole.hs
+++ b/src/ElmFormat/InputConsole.hs
@@ -3,8 +3,6 @@ module ElmFormat.InputConsole (InputConsole, InputConsoleF(..), readStdin, execu
 import Control.Monad.Free
 import Data.Text (Text)
 import ElmFormat.World
-import qualified Data.Text.Encoding as Text
-import qualified Data.ByteString.Lazy as Lazy
 
 
 class Functor f => InputConsole f where

--- a/src/ElmFormat/OutputConsole.hs
+++ b/src/ElmFormat/OutputConsole.hs
@@ -3,7 +3,6 @@ module ElmFormat.OutputConsole (OutputConsole, OutputConsoleF(..), writeStdout, 
 import Control.Monad.Free
 import Data.Text (Text)
 import ElmFormat.World (World)
-import qualified Data.Text.Encoding as Text
 import qualified ElmFormat.World as World
 
 

--- a/src/Messages/Formatter/HumanReadable.hs
+++ b/src/Messages/Formatter/HumanReadable.hs
@@ -7,7 +7,6 @@ import Messages.Formatter.Format
 import Messages.Types
 import CommandLine.Helpers (showErrors)
 import Messages.Strings (showPromptMessage)
-import System.IO (hFlush, stdout)
 import ElmFormat.World
 
 


### PR DESCRIPTION
Saves all warnings such as this one:

```
/.../elm-format/src/Messages/Formatter/HumanReadable.hs:10:1: warning: [-Wunused-imports]
    The import of ‘System.IO’ is redundant
      except perhaps to import instances from ‘System.IO’
    To import instances alone, use: import System.IO()
```

(There are still a lot of `-Wname-shadowing` warnings, but that's for another time)