### PR TITLE
stop assuming paths are files in error messages

### DIFF
--- a/src/Messages/Strings.hs
+++ b/src/Messages/Strings.hs
@@ -27,7 +27,7 @@ showErrorMessage ErrorsHeading = "ERRORS"
 
 showErrorMessage (BadInputFiles filePaths) =
   unlines
-    [ "There was a problem reading one or more of the specified input files:"
+    [ "There was a problem reading one or more of the specified INPUT paths:"
     , ""
     , unlines $ map ((++) "    " . showInputMessage) filePaths
     , "Please check the given paths."
@@ -55,7 +55,7 @@ showErrorMessage NoInputs =
 showInputMessage :: InputFileMessage -> String
 
 showInputMessage (FileDoesNotExist path) =
-    path ++ ": File does not exist"
+    path ++ ": No such file or directory"
 
 showInputMessage (NoElmFiles path) =
     path ++ ": Directory does not contain any *.elm files"


### PR DESCRIPTION
I changed error messages to talk about "files and directories" or "paths" instead of just "files".

If a user misspells a directory, a message saying "File does not exist" is confusing and suggests that elm-format cannot handle directories (it can).

Closes #503.
Also relevant #504.

---

I have not been able to test this change.