### PR TITLE
Add parentheses to import exposing clause if missing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -10,6 +10,7 @@ Copyright (c) 2013, John MacFarlane (Markdown parser forked from jgm/cheapskate)
 Copyright (c) 2017, Michael Maloney
 Copyright (c) 1999-2000, Daan Leijen. (part of Text.Parsec.Token)
 Copyright (c) 2007, Paolo Martini. (part of Text.Parsec.Token)
+Copyright (c) 2018, Andreas Scharf
 
 All rights reserved.
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -395,6 +395,7 @@ checkTransformation 0.18 DocCommentCheapskateReferenceBug.elm
 checkTransformation 0.18 DocCommentAtDocs.elm
 checkTransformation 0.18 Sorting.elm
 checkTransformation 0.18 UnnecessaryParens.elm
+checkTransformation 0.18 MissingImportParens.elm
 checkUpgrade 0.18 Elm-0.18/PrimesBecomeUnderscores.elm
 checkUpgrade 0.18 Elm-0.18/RangesBecomeListRange.elm
 checkUpgrade 0.18 Elm-0.18/BackticksBecomeFunctionCalls.elm

--- a/tests/test-files/transform/MissingImportParens.elm
+++ b/tests/test-files/transform/MissingImportParens.elm
@@ -1,0 +1,16 @@
+module Main exposing (x)
+
+import Import.As1 as ImportAs1
+import Import.As2 as ImportAs2 exposing A
+import ImportDotDot exposing ..
+import ImportName exposing A
+import ImportNames exposing A, B, x, y
+import ImportNamesLineBreak exposing
+    A, B
+import MergeImport exposing A, B
+import MergeImport exposing (Z)
+import OtherImport exposing (A(X, Y), b, z)
+
+
+x =
+    ()

--- a/tests/test-files/transform/MissingImportParens.formatted.elm
+++ b/tests/test-files/transform/MissingImportParens.formatted.elm
@@ -1,0 +1,14 @@
+module Main exposing (x)
+
+import Import.As1 as ImportAs1
+import Import.As2 as ImportAs2 exposing (A)
+import ImportDotDot exposing (..)
+import ImportName exposing (A)
+import ImportNames exposing (A, B, x, y)
+import ImportNamesLineBreak exposing (A, B)
+import MergeImport exposing (A, B, Z)
+import OtherImport exposing (A(X, Y), b, z)
+
+
+x =
+    ()


### PR DESCRIPTION
Solves #510

### Changes

This PR adds the case that import statements with missing parentheses are allowed and will get parsed successfully, even they're not valid elm syntax. Because this is convenience, I intentionally made the decision not to include line breaks or comments, to keep things simple.

```elm
-- Wrong
import Date exposing Date

-- Right
import Date exposing (Date)
```

I'm trying to learn more about Haskell and am therefore open for hints (also "Allow edits from maintainers"). And a follow up question: Is there code formatting for the Haskell code base? How to use it?