### PR TITLE
Simplify/correct vim installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Find your editor in the table below.  The recommended plugin for each editor is 
   <tr>
     <td rowspan=1>Vim</td>
     <td>:trophy: <a href="https://github.com/ElmCast/elm-vim">elm-vim</a></td>
-    <td>:x: <a href="#elm-vim-installation">6 steps</a></td>
+    <td>:warning: <a href="#elm-vim-installation">3 steps</a></td>
     <td>:white_check_mark:</td>
     <td>⚠️ requires configuration</td>
     <td>:white_check_mark:</td>
@@ -220,30 +220,7 @@ The default behavior of `elm-format`-approved plugins is to format Elm files on 
 ### elm-vim installation
 
 1. Install elm-format
-1. Install [vim-plug](https://github.com/junegunn/vim-plug) ([official instructions](https://github.com/junegunn/vim-plug#installation))
-
-    1. Download vim-plug:
-
-        ```bash
-        curl -fLo ~/.vim/autoload/plug.vim --create-dirs \
-            https://raw.githubusercontent.com/junegunn/vim-plug/master/plug.vim
-        ```
-
-   1. Make sure there is a section like this in your `~/.vimrc`:
-
-        ```vim
-        call plug#begin('~/.vim/plugged')
-        " ... any active plugins
-        call plug#end()
-        ```
-
-
-
-1. Install elm-vim ([official instructions](https://github.com/ElmCast/elm-vim#install))
-
-    1. Add `Plug 'elmcast/elm-vim'` to the `plug#begin` plugin section in your `~/.vimrc`
-    1. Start `vim` and run `:PlugInstall`
-
+1. Install elm-vim ([official instructions](https://github.com/ElmCast/elm-vim#installation))
 1. Add the following to your `~/.vimrc`:
 
   ```


### PR DESCRIPTION
The existing instructions included an overly detailed overview of how to begin using the package manager vim-plug and use it to install vim-elm. Vim-plug is not a requirement, and including installation instructions for it is unnecessary and outright dangerous.