### PR TITLE
Retain multiline exposings in module lines when there are no module docs

### DIFF
--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -333,6 +333,7 @@ checkUpgrade 0.19 Elm-0.19/OpenExplicitConstructorImports.elm
 checkGood 0.18 Simple.elm
 checkGood 0.18 AllSyntax/0.18/AllSyntax.elm
 checkGoodAllSyntax 0.18 Module
+checkGood 0.18 AllSyntax/0.18/ModuleMultiline.elm
 checkGood 0.18 AllSyntax/0.18/Declarations.elm
 checkGoodAllSyntax 0.18 Patterns
 checkGoodAllSyntax 0.18 Types

--- a/tests/test-files/good/AllSyntax/0.17/LineComments/Module.elm
+++ b/tests/test-files/good/AllSyntax/0.17/LineComments/Module.elm
@@ -7,18 +7,22 @@ module
     --C
     exposing
     --D
-    ( --K
-      D
-      --L
-    , --E
-      a
-      --F
-    , --G
-      b
-      --H
-    , --I
-      c
-      --J
+    (  --K
+       D
+       --L
+
+    ,  --E
+       a
+       --F
+
+    ,  --G
+       b
+       --H
+
+    ,  --I
+       c
+       --J
+
     )
 
 

--- a/tests/test-files/good/AllSyntax/0.17/LineComments/ModuleEffect.elm
+++ b/tests/test-files/good/AllSyntax/0.17/LineComments/ModuleEffect.elm
@@ -27,15 +27,18 @@ effect
     -- L
     exposing
     -- M
-    ( -- N
-      a
-      -- O
-    , -- P
-      b
-      -- Q
-    , -- R
-      c
-      -- S
+    (  -- N
+       a
+       -- O
+
+    ,  -- P
+       b
+       -- Q
+
+    ,  -- R
+       c
+       -- S
+
     )
 
 

--- a/tests/test-files/good/AllSyntax/0.18/LineComments/Module.elm
+++ b/tests/test-files/good/AllSyntax/0.18/LineComments/Module.elm
@@ -7,15 +7,18 @@ module
     --B
     --I
     exposing
-    ( --C
-      a
-      --D
-    , --E
-      b
-      --F
-    , --G
-      c
-      --H
+    (  --C
+       a
+       --D
+
+    ,  --E
+       b
+       --F
+
+    ,  --G
+       c
+       --H
+
     )
 
 --J

--- a/tests/test-files/good/AllSyntax/0.18/ModuleMultiline.elm
+++ b/tests/test-files/good/AllSyntax/0.18/ModuleMultiline.elm
@@ -1,0 +1,17 @@
+module AllSyntax.ModuleMultiline exposing
+    ( a
+    , b
+    , c
+    )
+
+
+a =
+    1
+
+
+b =
+    2
+
+
+c =
+    3

--- a/tests/test-files/transform/QuickCheck-4562ebccb71ea9f622fb99cdf32b2923f6f9d34f-2529668492575674138.formatted.elm
+++ b/tests/test-files/transform/QuickCheck-4562ebccb71ea9f622fb99cdf32b2923f6f9d34f-2529668492575674138.formatted.elm
@@ -3,10 +3,12 @@ module
     Main
     {- A -} exposing
     ( a
-    , b
-      --A
-    , --A
-      c
+    ,  b
+       --A
+
+    ,  --A
+       c
+
     )
 
 


### PR DESCRIPTION
Fixes https://github.com/avh4/elm-format/issues/520