### PR TITLE
Add instructions for Vim Ex command setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,22 @@ The default behavior of `elm-format`-approved plugins is to format Elm files on 
   ```
   let g:elm_format_autosave = 1
   ```
+  
+  
+### Vim Ex Command - pluginless alternative
+1. Add the following to your `~/.vimrc`:
+
+  ```vim
+  command ElmFormat :silent %!elm-format --stdin                 " defines a custom :ElmFormat ex command
+  nnoremap ef :ElmFormat<cr>                                     " bind the command to <leader> e f
+  autocmd FileType elm autocmd BufWritePre <buffer> :ElmFormat   " runs :ElmFormat on save
+  ```
+  
+or without the named command:
+
+ ```vim
+  autocmd FileType elm autocmd BufWritePre <buffer> :silent %!elm-format --stdin  " runs elm-format on save
+  ```
 
 
 ### Visual Studio Code installation


### PR DESCRIPTION
I didn't want to install the Vim plugin, but I want to run `elm-format` from Vim. This is a small Ex mode command that will run `elm-format` on a buffer save of an `.elm` file.

The first example is more verbose and adds an explicit `:ElmFormat` ex command as well as a leader key binding.

The second example just runs `elm-format` on save without defining an explicit Ex command.