### PR TITLE
Add script to generate the elm-format nix derivation for nixpkgs

### DIFF
--- a/package/nix/generate_derivation.sh
+++ b/package/nix/generate_derivation.sh
@@ -1,0 +1,50 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p git haskellPackages.cabal2nix nix-prefetch-git jq
+
+# This script generates the nix derivation for elm-format intended for nixpkgs:
+# https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/elm/packages/elm-format.nix
+
+# To use this script, update the FLAVOR to the most recent flavor of elm-format
+# and then run:
+#
+# $ ./generate_derivation.sh > elm-format.sh
+#
+# This might take a bit of time if the dependencies are not already in the nix
+# store. If you already have all the dependencies installed, feel free to remove
+# them from the shebang to speed up the process.
+
+FLAVOR="0.19"
+
+REV="$(git rev-parse HEAD)"
+VERSION="$(git describe --abbrev=8)"
+ROOTDIR="$(git rev-parse --show-toplevel)"
+SHA="$(nix-prefetch-git --url "$ROOTDIR" --rev "$REV" --quiet --no-deepClone | jq .sha256)"
+
+PATCH=$(cat <<END
+  src = fetchgit {
+    url = "http://github.com/avh4/elm-format";
+    sha256 = $SHA;
+    rev = "$REV";
+  };
+
+  doHaddock = false;
+  jailbreak = true;
+  postInstall = ''
+    ln -s \$out/bin/elm-format-$FLAVOR \$out/bin/elm-format
+  '';
+  postPatch = ''
+    sed -i "s|desc <-.*||" ./Setup.hs
+    sed -i "s|gitDescribe = .*|gitDescribe = \\\\\\\\\"$VERSION\\\\\\\\\"\"|" ./Setup.hs
+  '';
+END
+)
+
+# quoteSubst from https://stackoverflow.com/a/29613573
+quoteSubst() {
+  IFS= read -d '' -r < <(sed -e ':a' -e '$!{N;ba' -e '}' -e 's/[&/\]/\\&/g; s/\n/\\&/g' <<<"$1")
+  printf %s "${REPLY%$'\n'}"
+}
+
+cabal2nix "$ROOTDIR" |
+  sed "s#^{ mkDerivation#{ mkDerivation, fetchgit#" |
+  sed "s#\\s*src = .*;#$(quoteSubst "$PATCH")#"


### PR DESCRIPTION
This is a small script to automate part of the process of updating `elm-format` in `nixpkgs`. This script was briefly discussed in #529.

The script is heavily influenced by the current tricks and patches used in https://github.com/NixOS/nixpkgs/blob/2c50340575a4b91bd983894d294e5619ae4aee96/pkgs/development/compilers/elm/packages/elm-format.nix

I am not sure generating nix derivation like this is the cleanest/most maintainable thing to do. However it seems to work:

```zsh
➜ $(nix-build --no-out-link -A elmPackages.elm-format)/bin/elm-format --help
elm-format-0.19 0.8.0-2-g0c5b9425

Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
                  [--elm-version VERSION] [--upgrade]
  Format Elm source files.
```

Note: I haven't encountered the issue with the `indents` package @domenkozar mentioned in #529 (edit: probably because `jailbreak` is set to `true`)