### PR TITLE
Automate updating the nix package

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -67,3 +67,13 @@ npm dist-tag add elm-format@<new version> elm0.18.0
 npm dist-tag add elm-format@<new version> elm0.19.0
 npm dist-tag add elm-format@<new version> exp
 ```
+
+
+## Nix
+
+```
+cd package/nix
+./build.sh
+```
+
+Then `cd nixpkgs`, push the resulting branch, and make a PR to https://github.com/NixOS/nixpkgs with the title "elm-format: [old version] -> [new version]"

--- a/package/nix/.gitignore
+++ b/package/nix/.gitignore
@@ -1,0 +1,1 @@
+/nixpkgs

--- a/package/nix/build.sh
+++ b/package/nix/build.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+set -exo pipefail
+
+ELM_FORMAT_VERSION="$(git describe --abbrev=8)"
+BRANCH="elm-format-$ELM_FORMAT_VERSION"
+
+if [ ! -d nixpkgs ]; then
+  git clone https://github.com/NixOS/nixpkgs.git nixpkgs
+fi
+
+pushd nixpkgs
+git fetch origin master
+if git branch | grep " ${BRANCH}$"; then
+  git checkout "$BRANCH"
+  git reset --hard origin/master
+else
+  git checkout -b "$BRANCH" origin/master
+fi
+popd
+
+cabal2nix --no-check cabal://indents-0.3.3 > nixpkgs/pkgs/development/compilers/elm/packages/indents.nix
+cabal2nix --no-check cabal://tasty-quickcheck-0.9.2 > nixpkgs/pkgs/development/compilers/elm/packages/tasty-quickcheck.nix
+./generate_derivation.sh > nixpkgs/pkgs/development/compilers/elm/packages/elm-format.nix
+
+pushd nixpkgs
+rm -f result
+nix-build -A elmPackages.elm-format
+git status
+result/bin/elm-format | head -n1
+popd
+
+set +x
+
+echo
+echo "Everything looks good!"
+echo "You will need to make a PR from the $BRANCH branch"

--- a/package/nix/generate_derivation.sh
+++ b/package/nix/generate_derivation.sh
@@ -1,37 +1,30 @@
 #! /usr/bin/env nix-shell
-#! nix-shell -i bash -p git haskellPackages.cabal2nix nix-prefetch-git jq
+#! nix-shell -i bash -p git cabal2nix nix-prefetch-git jq
 
 # This script generates the nix derivation for elm-format intended for nixpkgs:
 # https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/elm/packages/elm-format.nix
 
-# To use this script, update the FLAVOR to the most recent flavor of elm-format
-# and then run:
+# To use this script, run:
 #
-# $ ./generate_derivation.sh > elm-format.sh
+# $ ./generate_derivation.sh > elm-format.nix
 #
 # This might take a bit of time if the dependencies are not already in the nix
 # store. If you already have all the dependencies installed, feel free to remove
 # them from the shebang to speed up the process.
 
-FLAVOR="0.19"
+set -exo pipefail
 
 REV="$(git rev-parse HEAD)"
-VERSION="$(git describe --abbrev=8)"
+VERSION="$(git describe --abbrev=8 "$REV")"
 ROOTDIR="$(git rev-parse --show-toplevel)"
-SHA="$(nix-prefetch-git --url "$ROOTDIR" --rev "$REV" --quiet --no-deepClone | jq .sha256)"
+SHA="$(nix-prefetch-git --url "$ROOTDIR" --rev "$REV" --quiet --no-deepClone | jq --raw-output .sha256)"
 
 PATCH=$(cat <<END
   src = fetchgit {
     url = "http://github.com/avh4/elm-format";
-    sha256 = $SHA;
+    sha256 = "$SHA";
     rev = "$REV";
   };
-
-  doHaddock = false;
-  jailbreak = true;
-  postInstall = ''
-    ln -s \$out/bin/elm-format-$FLAVOR \$out/bin/elm-format
-  '';
   postPatch = ''
     sed -i "s|desc <-.*||" ./Setup.hs
     sed -i "s|gitDescribe = .*|gitDescribe = \\\\\\\\\"$VERSION\\\\\\\\\"\"|" ./Setup.hs
@@ -45,6 +38,6 @@ quoteSubst() {
   printf %s "${REPLY%$'\n'}"
 }
 
-cabal2nix "$ROOTDIR" |
+cabal2nix --no-haddock "$ROOTDIR" |
   sed "s#^{ mkDerivation#{ mkDerivation, fetchgit#" |
   sed "s#\\s*src = .*;#$(quoteSubst "$PATCH")#"


### PR DESCRIPTION
Includes #530, and addresses #529.

cc @domenkozar @basile-henry

I've got this working to create an update branch against nixpkgs, and test it.

However, one remaining problem, if you build this (with `cd package/nix && ./build.sh`) and then run the compiled binary with `nixpkgs/result/bin/elm-format`, the compiled binary has an empty string for the version number, so I'm thinking maybe the postPatch sed lines aren't quite right, but I have to learn how to get nix-build to save the working directory for me so I can debug.