### PR TITLE
Fix #454, Remove (..) from types in @docs

### DIFF
--- a/src/ElmFormat/Render/Box.hs
+++ b/src/ElmFormat/Render/Box.hs
@@ -700,7 +700,18 @@ formatModuleDocs elmVersion importInfo blocks =
 
         content :: String
         content =
-            ElmFormat.Render.Markdown.formatMarkdown (fmap format . parse) blocks
+            ElmFormat.Render.Markdown.formatMarkdown (fmap format . parse) $ fmap cleanBlock blocks
+
+        cleanBlock :: Markdown.Block -> Markdown.Block
+        cleanBlock block =
+            case block of
+                Markdown.ElmDocs docs ->
+                    Markdown.ElmDocs $
+                        (fmap . fmap)
+                            (Text.replace (Text.pack "(..)") (Text.pack ""))
+                            docs
+                _ ->
+                    block
     in
         formatDocComment content
 

--- a/tests/test-files/transform/DocCommentAtDocs.elm
+++ b/tests/test-files/transform/DocCommentAtDocs.elm
@@ -1,4 +1,4 @@
-module DocCommentAtDocs exposing (x, y, z)
+module DocCommentAtDocs exposing (x, y, z, T(..))
 
 {-|
 
@@ -6,6 +6,7 @@ module DocCommentAtDocs exposing (x, y, z)
  x,
    y,
  z
+@docs T(..)
 
 @docs a  , b  ,   c    
 @docs d

--- a/tests/test-files/transform/DocCommentAtDocs.formatted.elm
+++ b/tests/test-files/transform/DocCommentAtDocs.formatted.elm
@@ -2,6 +2,7 @@ module DocCommentAtDocs exposing
     ( x
     , y
     , z
+    , T(..)
     )
 
 {-|
@@ -9,6 +10,7 @@ module DocCommentAtDocs exposing
 @docs x
 @docs y
 @docs z
+@docs T
 
 @docs a, b, c
 @docs d


### PR DESCRIPTION
Fixes #454.

This adds a cleanup pass before rendering the module docs content. It removes `(..)` if any in the `Markdown.ElmDocs`.

I'm not sure if this is the best place to put this pass but I figured if it's done in the formatting function it will not break other stuff and will not miss any `(..)` it's supposed to remove.

I'm not very familiar with haskell so my `Text.replace (Text.pack "(..)") (Text.pack "")` thing might not be the best way of doing this.