### PR TITLE
Use trackNewlines instead of pop and push functions

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -12,6 +12,8 @@ Copyright (c) 1999-2000, Daan Leijen. (part of Text.Parsec.Token)
 Copyright (c) 2007, Paolo Martini. (part of Text.Parsec.Token)
 Copyright (c) 2018, Andreas Scharf
 Copyright (c) 2018, Matthias Devlamynck
+Copyright (c) 2018, Juliano Bortolozzo Solanho
+
 
 All rights reserved.
 

--- a/parser/src/Parse/Comments.hs
+++ b/parser/src/Parse/Comments.hs
@@ -5,6 +5,7 @@ import Parse.IParser
 import AST.V0_16
 
 
+
 commented :: IParser a -> IParser (Commented a)
 commented inner =
     Commented <$> whitespace <*> inner <*> whitespace
@@ -23,9 +24,7 @@ preCommented a =
 withEol :: IParser a -> IParser (WithEol a)
 withEol a =
     do
-        pushNewlineContext
-        result <- a
-        multiline <- popNewlineContext
-        if multiline
-            then return (result, Nothing)
-            else (,) result <$> restOfLine
+        (result, multiline) <- trackNewline a
+        case multiline of
+            SplitAll -> return (result, Nothing)
+            JoinAll -> (,) result <$> restOfLine

--- a/parser/src/Parse/Common.hs
+++ b/parser/src/Parse/Common.hs
@@ -49,7 +49,5 @@ sectionedGroup term =
 checkMultiline :: IParser (ForceMultiline -> a) -> IParser a
 checkMultiline inner =
     do
-        pushNewlineContext
-        a <- inner
-        multiline <- popNewlineContext
-        return $ a (ForceMultiline multiline)
+        (a, multiline) <- trackNewline inner
+        return $ a (ForceMultiline $ multilineToBool multiline)

--- a/parser/src/Parse/Expression.hs
+++ b/parser/src/Parse/Expression.hs
@@ -138,10 +138,8 @@ head' (a:_) = Just a
 appExpr :: IParser E.Expr
 appExpr =
   expecting "an expression" $
-  do  pushNewlineContext
-      start <- getMyPosition
-      t <- term
-      sawNewlineInInitialTerm <- popNewlineContext
+  do  start <- getMyPosition
+      (t, initialTermMultiline) <- trackNewline term
       ts <- constrainedSpacePrefix term
       end <- getMyPosition
       return $
@@ -152,15 +150,15 @@ appExpr =
                 let
                     multiline =
                         case
-                            ( sawNewlineInInitialTerm
+                            ( initialTermMultiline
                             , fromMaybe (JoinAll) $ fmap snd $ head' ts
                             , any (isMultiline . snd) $ tail ts
                             )
                         of
-                            (True, _, _ ) -> FASplitFirst
-                            (False, JoinAll, True) -> FAJoinFirst SplitAll
-                            (False, JoinAll, False) -> FAJoinFirst JoinAll
-                            (False, SplitAll, _) -> FASplitFirst
+                            (SplitAll, _, _ ) -> FASplitFirst
+                            (JoinAll, JoinAll, True) -> FAJoinFirst SplitAll
+                            (JoinAll, JoinAll, False) -> FAJoinFirst JoinAll
+                            (JoinAll, SplitAll, _) -> FASplitFirst
                 in
                     A.at start end $ E.App t (fmap fst ts) multiline
 
@@ -217,27 +215,29 @@ ifClause =
 
 lambdaExpr :: IParser E.Expr
 lambdaExpr =
-  addLocation $
-  do  pushNewlineContext
+  let
+    subparser = do
       _ <- char '\\' <|> char '\x03BB' <?> "an anonymous function"
       args <- spacePrefix Pattern.term
       (preArrowComments, _, bodyComments) <- padded rightArrow
       body <- expr
-      multiline <- popNewlineContext
-      return $ E.Lambda args (preArrowComments ++ bodyComments) body multiline
+      return (args, preArrowComments, bodyComments, body)
+  in
+    addLocation $
+        do  ((args, preArrowComments, bodyComments, body), multiline) <- trackNewline subparser
+            return $ E.Lambda args (preArrowComments ++ bodyComments) body $ multilineToBool multiline
 
 
 caseExpr :: IParser E.Expr'
 caseExpr =
   do  try (reserved "case")
-      pushNewlineContext
-      e <- (\(pre, e, post) -> Commented pre e post) <$> padded expr
+      (e, multilineSubject) <- trackNewline $ (\(pre, e, post) -> Commented pre e post) <$> padded expr
       reserved "of"
-      multilineSubject <- popNewlineContext
       firstPatternComments <- whitespace
+      -- We think this is bc of the bug where newlines don't propagate to outer contexts, let's see if things break by commenting it
       updateState $ State.setNewline -- because if statements are always formatted as multiline, we pretend we saw a newline here to avoid problems with the Box rendering model
       result <- cases firstPatternComments
-      return $ E.Case (e, multilineSubject) result
+      return $ E.Case (e, multilineToBool multilineSubject) result
   where
     case_ preComments =
       do

--- a/parser/src/Parse/Expression.hs
+++ b/parser/src/Parse/Expression.hs
@@ -234,8 +234,6 @@ caseExpr =
       (e, multilineSubject) <- trackNewline $ (\(pre, e, post) -> Commented pre e post) <$> padded expr
       reserved "of"
       firstPatternComments <- whitespace
-      -- We think this is bc of the bug where newlines don't propagate to outer contexts, let's see if things break by commenting it
-      updateState $ State.setNewline -- because if statements are always formatted as multiline, we pretend we saw a newline here to avoid problems with the Box rendering model
       result <- cases firstPatternComments
       return $ E.Case (e, multilineToBool multilineSubject) result
   where

--- a/parser/src/Parse/Whitespace.hs
+++ b/parser/src/Parse/Whitespace.hs
@@ -78,18 +78,6 @@ simpleNewline =
       return ()
 
 
-pushNewlineContext :: IParser ()
-pushNewlineContext =
-    updateState State.pushNewlineContext
-
-
-popNewlineContext :: IParser Bool
-popNewlineContext =
-  do  state <- getState
-      updateState State.popNewlineContext
-      return $ State.sawNewline state
-
-
 trackNewline :: IParser a -> IParser (a, Multiline)
 trackNewline parser =
     do


### PR DESCRIPTION
The wrapping makes some things uglier, but we believe this will make it easier to incorporate the 19 parser into the codebase.