### PR TITLE
Reference prettier-plugin-elm from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Find your editor in the table below.  The recommended plugin for each editor is 
 </table>
 
 Alternatively, you can utilize elm-format via a [Prettier plugin](https://github.com/gicentre/prettier-plugin-elm) that wraps it.
-This can be convenient if your project contains files in other languages like JavaScript, Markdown, etc.
+This can be convenient if your project contains files in other languages and you want to format all of them using a single API.
 [Prettier](https://prettier.io/) has its own integrations into editors and can also be used from a command line (including CI pipelines).
 
 ## Detailed instructions

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ Find your editor in the table below.  The recommended plugin for each editor is 
   </tr>
 </table>
 
+Alternatively, you can utilize elm-format via a [Prettier plugin](https://github.com/gicentre/prettier-plugin-elm) that wraps it.
+This can be convenient if your project contains files in other languages like JavaScript, Markdown, etc.
+[Prettier](https://prettier.io/) has its own integrations into editors and can also be used from a command line (including CI pipelines).
 
 ## Detailed instructions
 


### PR DESCRIPTION
Just thought that a link to [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm) could be potentially useful to newcomers (especially given that Prettier is getting very popular amongst people who write JavaScript and Markdown).

Congratulations on 1,000 GitHub stars @avh4! 🌟 