### PR TITLE
Update and clarify VSCode installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,18 +251,13 @@ The default behavior of `elm-format`-approved plugins is to format Elm files on 
 > Note: If you previously installed a VSCode extension called "elm-format", uninstall it (it is deprecated, and the "elm" extension now provides elm-format integration).
 
 1. Install elm-format
-1. Install [Elm Language Support](https://marketplace.visualstudio.com/items?itemName=sbrink.elm) for VSCode
-
-    ```bash
-    ext install elm
-    ```
-
+1. Install the extension [Elm Language Support](https://marketplace.visualstudio.com/items?itemName=sbrink.elm) for VSCode, which includes syntax and error highlighting
 1. Configure the extension to format on save:
 
-    1. Go to `Preferences -> Settings` in the menu
-    1. In your User Settings, update the following value:
-    
-    ```
+    1. Find your `settings.json` file ([instructions](https://code.visualstudio.com/docs/getstarted/settings#_settings-file-locations)).
+    1. Add the following key-value pair to your `settings.json`:
+
+    ```json
     "[elm]": {
         "editor.formatOnSave": true
     },


### PR DESCRIPTION
I'm assuming people know where to find the Extensions menu in VSCode, and how to download the extension named elm. 

I'm also assuming people won't already have a field visible in the UI for VSCode settings called `"[elm]"` that is editable in the UI, so we're going to have to open up `settings.json` and add the field manually. I've linked to the VSCode docs, which will tell you where to find your `settings.json` file based on your operating system. 

I don't want people to copy-and-paste the json outside of the `{}`. I wanted to say something like "add this somewhere in the top level of your json blob" but thought that would just be confusing--they might misunderstand and think I'm saying "top of the file," but all I'm trying to say is "within the outermost `{` and `}`". So I kept the wording very simple. What do you think?

Thank you for ElmBridge!!