### PR TITLE
GHC 8.8.1 compatibility

### DIFF
--- a/markdown/Cheapskate/ParserCombinators.hs
+++ b/markdown/Cheapskate/ParserCombinators.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Cheapskate.ParserCombinators (
     Position(..)
   , Parser
@@ -37,6 +38,7 @@ import qualified Data.Text as T
 import Control.Monad
 import Control.Applicative
 import qualified Data.Set as Set
+import qualified Control.Monad.Fail as Fail
 
 data Position = Position { line :: Int, column :: Int }
      deriving (Ord, Eq)
@@ -107,9 +109,14 @@ instance Alternative Parser where
   {-# INLINE empty #-}
   {-# INLINE (<|>) #-}
 
+instance Fail.MonadFail Parser where
+  fail e = Parser $ \st -> Left $ ParseError (position st) e
+
 instance Monad Parser where
   return x = Parser $ \st -> Right (st, x)
-  fail e = Parser $ \st -> Left $ ParseError (position st) e
+#if !MIN_VERSION_base(4,13,0)
+  fail = Fail.fail
+#endif
   p >>= g = Parser $ \st ->
     case evalParser p st of
          Left e        -> Left e


### PR DESCRIPTION
related to https://github.com/NixOS/nixpkgs/pull/71538#issuecomment-544671581 this is an attempt to patch build for latest GHC versions.

Tests are failing with GHC 8.8.1 but it's probably just a minor change in dependencies

<details>
Test suite elm-format-tests: RUNNING...
elm-format
  example test group
    simple AST round trip:                                       OK
    rendered AST should parse as equivalent AST:                 OK (0.12s)
      +++ OK, passed 100 tests.
    valid Elm files
      should parse:                                              OK (0.03s)
        +++ OK, passed 100 tests.
      should parse to the same AST after formatting:             OK (0.08s)
        +++ OK, passed 100 tests.
    simple round trip:                                           OK
    simple round trip with comments:                             OK
    simple round trip with comments:                             OK
  ElmFormat.Render.BoxTest
    keyword:                                                     OK
    identifier:                                                  OK
    punctuation:                                                 OK
    row:                                                         OK
    space:                                                       OK
    stack1:                                                      OK
    indent:                                                      OK
    indent (with leading spaces):                                OK
  ElmFormat.Render.ElmStructure
    application (single line):                                   OK
    application (multiline):                                     OK
    group (empty):                                               OK
    group (single item, single line):                            OK
    group (single line):                                         OK
    group (single line, no spaces):                              OK
    group (multiline):                                           OK
    group (forced multiline):                                    OK
  CLI
    usage:                                                       OK
    usage instructions:                                          FAIL
      Test output was different from 'tests/usage.stdout'. Output of ["diff","-u","tests/usage.stdout","/build/usage.stdout1513-0.actual"]:
      --- tests/usage.stdout    1970-01-01 00:00:01.000000000 +0000
      +++ /build/usage.stdout1513-0.actual      2019-10-21 20:33:52.403655638 +0000
      @@ -1,6 +1,6 @@
       elm-format x.x.x

      -Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
      +Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
                         [--elm-version VERSION] [--upgrade]
         Format Elm source files.

    simple file:                                                 OK
    using --stdin writes errors to stderr:                       OK
    auto-detects Elm version
      for Elm 0.19 applications:                                 OK
      for Elm 0.19 packages:                                     OK
      for Elm 0.18:                                              OK
      default to Elm 0.19:                                       OK
    ways to run
      elm-format --help
        exit code:                                               OK
        stdout:                                                  FAIL
          Test output was different from 'tests/usage.stdout'. Output of ["diff","-u","tests/usage.stdout","/build/usage.stdout1513-2.actual"]:
          --- tests/usage.stdout        1970-01-01 00:00:01.000000000 +0000
          +++ /build/usage.stdout1513-2.actual  2019-10-21 20:33:52.409655985 +0000
          @@ -1,6 +1,6 @@
           elm-format x.x.x

          -Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
          +Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
                             [--elm-version VERSION] [--upgrade]
             Format Elm source files.

      elm-format -h
        exit code:                                               OK
        stdout:                                                  FAIL
          Test output was different from 'tests/usage.stdout'. Output of ["diff","-u","tests/usage.stdout","/build/usage.stdout1513-3.actual"]:
          --- tests/usage.stdout        1970-01-01 00:00:01.000000000 +0000
          +++ /build/usage.stdout1513-3.actual  2019-10-21 20:33:52.410656042 +0000
          @@ -1,6 +1,6 @@
           elm-format x.x.x

          -Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
          +Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
                             [--elm-version VERSION] [--upgrade]
             Format Elm source files.

      elm-format (no args)
        exit code:                                               OK
        stdout:                                                  FAIL
          Test output was different from 'tests/usage.stdout'. Output of ["diff","-u","tests/usage.stdout","/build/usage.stdout1513-4.actual"]:
          --- tests/usage.stdout        1970-01-01 00:00:01.000000000 +0000
          +++ /build/usage.stdout1513-4.actual  2019-10-21 20:33:52.411656100 +0000
          @@ -1,6 +1,6 @@
           elm-format x.x.x

          -Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
          +Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
                             [--elm-version VERSION] [--upgrade]
             Format Elm source files.

      elm-format INPUT --yes does change the file:               OK
      elm-format INPUT --validate does not change things:        OK
      elm-format INPUT --validate with unformatted file exits 1: OK
      elm-format INPUT --validate with formatted file exits 0:   OK
  Literals
    1:                                                           OK
    0:                                                           OK
    -1:                                                          OK
    536870911:                                                   OK
    -536870911:                                                  OK
    0x00:                                                        OK
    0xFF:                                                        OK
    0x07FF:                                                      OK
    0x00010000:                                                  OK
    0x0000000100000000:                                          OK
    0xabcdef00:                                                  OK
    0x1:                                                         OK
    0x111:                                                       OK
    0x11111:                                                     OK
    0x111111111:                                                 OK
    2.0:                                                         OK
    0.01:                                                        OK
    1.0e-2:                                                      OK
    9.11e23:                                                     OK
  Parse.Expression
    Unit
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    Literal
      :                                                          OK
      Boolean
        True:                                                    OK
        False:                                                   OK
    variable
      lowercase:                                                 OK
      uppercase:                                                 OK
      qualified:                                                 OK
      symbolic operator
        :                                                        OK
        does not allow whitespace:                               OK
        doew not allow comments:                                 OK
    function application
      :                                                          OK
      argument starts with minus:                                OK
      comments:                                                  OK
      newlines (1):                                              OK
      newlines (2):                                              OK
      newlines and comments:                                     OK
    unary operators
      negative
        :                                                        OK
        must not have whitespace:                                OK
        must not have comment:                                   OK
        does not apply to '-':                                   OK
        does not apply to '.':                                   OK
    binary operators
      :                                                          OK
      minus with no whitespace:                                  OK
      backticks:                                                 OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    parentheses
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    empty list
      empty:                                                     OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    List
      :                                                          OK
      single element:                                            OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    Range
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    Tuple
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    tuple constructor
      :                                                          OK
      does not allow whitespace (1):                             OK
      does not allow whitespace (2):                             OK
      does not allow whitespace (3):                             OK
      does not allow comments (1):                               OK
      does not allow comments (2):                               OK
      does not allow comments (3):                               OK
    Record
      empty
        :                                                        OK
        whitespace:                                              OK
        comments:                                                OK
      :                                                          OK
      single field:                                              OK
      whitespace:                                                OK
      comments:                                                  OK
      single field with comments:                                OK
      newlines:                                                  OK
    Record update
      :                                                          OK
      single field:                                              OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
      only allows simple base:                                   OK
      only allows simple base:                                   OK
      no fields (elm-compiler does not allow this):              OK
    record access
      :                                                          OK
      nested:                                                    OK
      does not allow symbolic field names:                       OK
      does not allow symbolic field names:                       OK
    record access fuction
      :                                                          OK
    lambda
      :                                                          OK
      single parameter:                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
      arrow must not contain whitespace:                         OK
    if statement
      :                                                          OK
      comments:                                                  OK
      else if:                                                   OK
      newlines:                                                  OK
    let statement
      :                                                          OK
      multiple declarations:                                     OK
      multiple declarations:                                     OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
      must have at least one definition:                         OK
      declarations must start at the same column
        (1):                                                     OK
        (2):                                                     OK
        (3):                                                     OK
    case statement
      :                                                          OK
      no newline after 'of':                                     OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
      should not consume trailing whitespace:                    OK
      clauses must start at the same column
        (1):                                                     OK
        (2):                                                     OK
        (3):                                                     OK
  Parse.Helpers
    parens''
      single term:                                               OK
      whitespace:                                                OK
      comments:                                                  OK
      multiple terms:                                            OK
      whitespace:                                                OK
      no terms:                                                  OK
      whitespace:                                                OK
      comments:                                                  OK
  Parse.Literal
    Int
      :                                                          OK
      negative:                                                  OK
      hexadecimal
        small:                                                   OK
        medium:                                                  OK
        large:                                                   OK
        huge:                                                    OK
      hexadecimal must start with 0:                             OK
      hexadecimal, must contain digits:                          OK
    Float
      :                                                          OK
      negative:                                                  OK
      exponent:                                                  OK
      positive exponent:                                         OK
      negative exponent:                                         OK
      capital exponent:                                          OK
      exponent must have exponent digits:                        OK
      exponent must have digits:                                 OK
      exponent and decimal:                                      OK
      exponent and decimal, must have decimal digits:            OK
      must have digits:                                          OK
      must start with a digit:                                   OK
      decimal, must have decimal digits:                         OK
    String
      :                                                          OK
      empty:                                                     OK
      escaped double quote:                                      OK
    multiline String
      :                                                          OK
    Char
      :                                                          OK
      escaped single quote:                                      OK
      Char (must have one character):                            OK
      Char (must have only one character):                       OK
  Parse.Pattern
    wildcard:                                                    OK
    literal:                                                     OK
    variable:                                                    OK
    data
      :                                                          OK
      single parameter:                                          OK
      comments:                                                  OK
      newlines:                                                  OK
    unit
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    parentheses
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    tuple
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    empty list pattern
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    list
      :                                                          OK
      single element:                                            OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    record
      :                                                          OK
      single element:                                            OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
      empty:                                                     OK
    alias
      :                                                          OK
      left side has whitespace:                                  OK
      left side ctor without whitespace:                         OK
      comments:                                                  OK
      newlines:                                                  OK
      nested:                                                    OK
      nested (whitespace):                                       OK
      nesting required parentheses:                              OK
  Parse.Type
    tuple type
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
    record type
      empty
        :                                                        OK
        whitespace:                                              OK
        comments:                                                OK
      :                                                          OK
      whitespace:                                                OK
      comments:                                                  OK
      single field with comments:                                OK
      newlines:                                                  OK
    record extension type
      :                                                          OK
      single field:                                              OK
      whitespace:                                                OK
      comments:                                                  OK
      newlines:                                                  OK
      only allows simple base:                                   OK
      only allows simple base:                                   OK
      no fields (elm-compiler does not allow this):              OK
  TestHelpers
    generateReplacements
      empty:                                                     OK
      single match:                                              OK
      multiple matches:                                          OK
  Util.List
    pairs
      :                                                          OK
      empty:                                                     OK
      single:                                                    OK
    intersperseMap
      :                                                          OK
      empty:                                                     OK
    shift
      :                                                          OK
      :                                                          OK
</details>

https://github.com/NixOS/nixpkgs/pull/71583