### PR TITLE
Fix #642 Bad performance/memory leak for long list literals

### DIFF
--- a/src/Box.hs
+++ b/src/Box.hs
@@ -119,7 +119,7 @@ stack1 children =
         [first] ->
             first
         boxes ->
-            foldl1 stack' boxes
+            foldr1 stack' boxes
 
 
 mapLines :: (Line -> Line) -> Box -> Box


### PR DESCRIPTION
A one-character fix that speeds up the formatting of long literals
and drastically reduces memory usage.

A very simple example is

```elm
module Small exposing (x)

x =
    [ 1, 2, 3
     , 4]
```

But with a list literal of many thousands of elements. The newline
forces all elements to get their own line. This is implemented as a
fold, but in practice this would often perform

```
longList ++ shortList
```

By reversing the fold (from `foldl` to `foldr`) that turns into

```
shortList ++ longList
```

Which requires less traversals and memory.

There are test files and profiling outputs in the issue #642. 