### PR TITLE
Never transform links to autolinks

### DIFF
--- a/markdown/Cheapskate/Inlines.hs
+++ b/markdown/Cheapskate/Inlines.hs
@@ -415,15 +415,14 @@ pAutolink = do
          | otherwise   -> fail "Unknown contents of <>"
 
 autoLink :: Text -> Inlines
-autoLink t = singleton $ Link (toInlines t) (Url t) (T.empty)
-  where toInlines t' = case parse pToInlines t' of
-                         Right r   -> r
-                         Left e    -> error $ "autolink: " ++ show e
-        pToInlines = mconcat <$> many strOrEntity
+autoLink t =
+  case parse pToInlines t of
+      Right _ -> singleton $ Autolink t
+      Left e  -> error $ "autolink: " ++ show e
+  where pToInlines = mconcat <$> many strOrEntity
         strOrEntity = ((singleton . Str) <$> takeWhile1 (/='&'))
                    <|> pEntity
                    <|> ((singleton . Str) <$> string "&")
 
 emailLink :: Text -> Inlines
-emailLink t = singleton $ Link (singleton $ Str t)
-                               (Url $ "mailto:" <> t) (T.empty)
+emailLink t = singleton $ Autolink ("mailto:" <> t)

--- a/markdown/Cheapskate/Types.hs
+++ b/markdown/Cheapskate/Types.hs
@@ -46,6 +46,7 @@ data Inline = Str Text
             | Strong Inlines
             | Code Text
             | Link Inlines LinkTarget {- URL -} Text {- title -}
+            | Autolink Text
             | Image Inlines Text {- URL -} Text {- title -}
             | Entity Text
             | RawHtml Text

--- a/src/ElmFormat/Render/Markdown.hs
+++ b/src/ElmFormat/Render/Markdown.hs
@@ -170,6 +170,14 @@ formatMarkdownInline fixSpecialChars inline =
         Code text ->
             "`" ++ Text.unpack text ++ "`" -- TODO: escape backticks
 
+        Autolink url ->
+            let
+                url' = Text.unpack url
+            in
+                if fixSpecialChars
+                    then "<" ++ url' ++ ">"
+                    else url'
+
         Link inlines (Url url) title ->
             let
                 text = fold $ fmap (formatMarkdownInline False) $ inlines
@@ -177,16 +185,10 @@ formatMarkdownInline fixSpecialChars inline =
                 title' = Text.unpack title
                 url' = Text.unpack url
             in
-                if text == url' && title' == ""
-                    then
-                        if fixSpecialChars
-                            then "<" ++ url' ++ ">"
-                            else url'
-                    else
-                        "[" ++ text
-                            ++ "](" ++ Text.unpack url
-                            ++ (if title' == "" then "" else " \"" ++ title' ++ "\"")
-                            ++ ")"
+                "[" ++ text
+                ++ "](" ++ Text.unpack url
+                ++ (if title' == "" then "" else " \"" ++ title' ++ "\"")
+                ++ ")"
 
         Link inlines (Ref ref) _ ->
             let

--- a/tests/test-files/good/Elm-0.19/AllSyntax/Doc.elm
+++ b/tests/test-files/good/Elm-0.19/AllSyntax/Doc.elm
@@ -1,0 +1,24 @@
+module AllSyntax.Doc exposing (links)
+
+{-| Documentation
+
+docs links
+
+-}
+
+
+{-| Markdown links
+
+Links:
+
+  - Link to [Module](Module).
+
+Autolinks:
+
+  - <https://host.domain>
+  - <host.domain>
+  - <mailto:me@domain>
+
+-}
+links =
+    []


### PR DESCRIPTION
This fixes one bug raised in https://github.com/avh4/elm-format/issues/339
that was causing links to modules like `[Module](Module)` being
transformed to invalid autolinks like `<Module>`.