### PR TITLE
Add some short options to CLI

### DIFF
--- a/src/Flags.hs
+++ b/src/Flags.hs
@@ -122,6 +122,7 @@ yes =
     Opt.switch $
         mconcat
         [ Opt.long "yes"
+        , Opt.short 'y'
         , Opt.help "Reply 'yes' to all automated prompts."
         ]
 
@@ -147,6 +148,7 @@ output =
     Opt.optional $ Opt.strOption $
         mconcat
         [ Opt.long "output"
+        , Opt.short 'o'
         , Opt.metavar "FILE"
         , Opt.help "Write output to FILE instead of overwriting the given source file."
         ]

--- a/tests/usage.stdout
+++ b/tests/usage.stdout
@@ -1,14 +1,14 @@
 elm-format x.x.x
 
-Usage: elm-format [INPUT] [--output FILE] [--yes] [--validate] [--stdin]
+Usage: elm-format [INPUT] [-o|--output FILE] [-y|--yes] [--validate] [--stdin]
                   [--elm-version VERSION] [--upgrade]
   Format Elm source files.
 
 Available options:
   -h,--help                Show this help text
-  --output FILE            Write output to FILE instead of overwriting the given
+  -o,--output FILE         Write output to FILE instead of overwriting the given
                            source file.
-  --yes                    Reply 'yes' to all automated prompts.
+  -y,--yes                 Reply 'yes' to all automated prompts.
   --validate               Check if files are formatted without changing them.
   --stdin                  Read from stdin, output to stdout.
   --elm-version VERSION    The Elm version of the source files being formatted.


### PR DESCRIPTION
It seems like `elm-format` should have some short options for users on the command line. The most obvious candidates are `--yes` and `--output`. It would be interesting to hear arguments for other short arguments from the community.

I built and test this on Linux, via

```
stack setup
stack install shake
stack runhaskell Shakefile.hs -- build
stack runhaskell Shakefile.hs -- test
```