### PR TITLE
Suggest simplify test running instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,8 @@ stack runhaskell Shakefile.hs -- build
 
 ### Running tests
 
+First follow steps under `Building from source`. Then run `Shakefile.hs` without arguments, as this will run all tests:
+
 ```bash
-stack install shake
 stack runhaskell Shakefile.hs
 ```


### PR DESCRIPTION
I noticed that the step `stack install shake` was duplicated under both headings, so this is an attempt to simplify. Does that make sense?