### PR TITLE
Refer to elm-mode for instructions on customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,7 @@ The default behavior of `elm-format`-approved plugins is to format Elm files on 
 
     1. Install elm-mode ([official instructions](https://github.com/jcollard/elm-mode#installation)): Use `M-x list-packages` and choose `elm-mode`.
 
-1. Set `elm-format-on-save` to `t` to apply elm-format on the current buffer on every save. (The setting can be changed via `M-x customize-variable elm-format-on-save`. Click button `Toggle` to change the setting and button `State` to activate the setting.)
-
+1. [Enable `elm-format-on-save-mode`](https://github.com/jcollard/elm-mode#elm-format) to apply elm-format on the current buffer on every save. 
 
 ### elm-vim installation
 


### PR DESCRIPTION
Enabling elm-format in Emacs via [`M-x customize-variable elm-format-on-save` is obsolete](https://github.com/jcollard/elm-mode/blob/master/elm-format.el#L31).