### PR TITLE
in doc comments, non-Elm code blocks are no longer elm-formatted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ New features:
   - newlines in tuple types are now preserved
   - newlines in type constructor application are now preserved
 
+Bug fixes:
+  - in doc comments, non-Elm code blocks are no longer elm-formatted
+
 
 ## 0.8.3
 

--- a/src/ElmFormat/Render/Markdown.hs
+++ b/src/ElmFormat/Render/Markdown.hs
@@ -90,8 +90,14 @@ formatMardownBlock formatCode context block =
 
         CodeBlock (CodeAttr lang _info) code ->
             let
+                isElm =
+                    lang' == "elm" || lang' == ""
+
                 formatted =
-                    fromMaybe (Text.unpack $ ensureNewline code) $ formatCode $ Text.unpack code
+                    fromMaybe (Text.unpack $ ensureNewline code) $
+                        if isElm
+                            then formatCode $ Text.unpack code
+                            else Nothing
 
                 ensureNewline text =
                     if Text.last text == '\n'
@@ -100,9 +106,6 @@ formatMardownBlock formatCode context block =
 
                 lang' =
                     Text.unpack lang
-
-                isElm =
-                    lang' == "elm" || lang' == ""
 
                 canIndent =
                     case context of

--- a/tests/test-files/good/Elm-0.18/AllSyntax/DocComments.elm
+++ b/tests/test-files/good/Elm-0.18/AllSyntax/DocComments.elm
@@ -78,7 +78,7 @@ Followed by a paragraph.
     y /= ()
 
 
-## Elm code lbock: only a module line
+## Elm code block: only a module line
 
     module Foo exposing (x)
 
@@ -103,6 +103,10 @@ Followed by a paragraph.
 
 ```bash
 echo "non-Elm code block"
+```
+
+```sh
+elm-review --template jfmengels/elm-review-noop/preview --rules NoNoOpMsg
 ```
 
 ---


### PR DESCRIPTION
Fixes https://github.com/avh4/elm-format/issues/687