### PR TITLE
in doc comments, inline code containing backticks is now escaped corr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ New features:
 Bug fixes:
   - special characters in link text in doc comments are now handled more correctly
   - in doc comments, non-Elm code blocks are no longer elm-formatted
+  - in doc comments, inline code containing backticks is now escaped correctly
 
 
 ## 0.8.3

--- a/elm-format.cabal
+++ b/elm-format.cabal
@@ -53,6 +53,7 @@ library
         AST.V0_16
         AST.Variable
         Box
+        Data.Text.Extra
         Elm.Utils
         ElmFormat.Parse
         ElmFormat.Render.Box
@@ -163,6 +164,7 @@ test-Suite elm-format-tests
     other-modules:
         BoxTest
         CommonMarkTests
+        Data.Text.ExtraTest
         ElmFormat.Render.ElmStructureTest
         ElmFormat.TestWorld
         Integration.CliTest

--- a/src/Data/Text/Extra.hs
+++ b/src/Data/Text/Extra.hs
@@ -1,0 +1,36 @@
+module Data.Text.Extra (longestSpanOf, LongestSpanResult(..)) where
+
+import Elm.Utils ((|>))
+
+import qualified Data.Text as Text
+import Data.Text (Text)
+import qualified Data.Maybe as Maybe
+
+
+data LongestSpanResult
+    = NoSpan
+    | Span Int {- >= 1 -}
+    deriving (Eq, Show)
+
+
+longestSpanOf :: Char -> Text -> LongestSpanResult
+longestSpanOf char input =
+    case Text.foldl' step (Nothing, 0) input |> endCurrentSpan of
+        0 -> NoSpan
+        positive -> Span positive
+    where
+        step (currentSpan, longest) c =
+            if c == char
+                then
+                    ( Just (1 + Maybe.fromMaybe 0 currentSpan)
+                    , longest
+                    )
+                else
+                    ( -- clear the current span
+                      Nothing
+                    , -- and update the longest
+                      endCurrentSpan (currentSpan, longest)
+                    )
+
+        endCurrentSpan (Nothing, longest) = longest
+        endCurrentSpan (Just current, longest) = max current longest

--- a/src/ElmFormat/Render/Markdown.hs
+++ b/src/ElmFormat/Render/Markdown.hs
@@ -6,6 +6,7 @@ import qualified Data.List as List
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as Text
 import Data.Text (Text)
+import Data.Text.Extra (longestSpanOf, LongestSpanResult(..))
 import Elm.Utils ((|>))
 
 
@@ -171,7 +172,13 @@ formatMarkdownInline fixSpecialChars inline =
         Strong inlines ->
             "**" ++ (fold $ fmap (formatMarkdownInline True) $ inlines) ++ "**" -- TODO: escaping
         Code text ->
-            "`" ++ Text.unpack text ++ "`" -- TODO: escape backticks
+            case longestSpanOf '`' text of
+                NoSpan -> "`" ++ Text.unpack text ++ "`"
+                Span n ->
+                    let
+                        delimiter = replicate (n + 1) '`'
+                    in
+                    delimiter ++ " " ++ Text.unpack text ++ " " ++ delimiter
 
         Link inlines (Url url) title ->
             let

--- a/tests/Data/Text/ExtraTest.hs
+++ b/tests/Data/Text/ExtraTest.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Data.Text.ExtraTest (tests) where
+
+import Elm.Utils ((|>))
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import qualified Data.Text as Text
+
+import Data.Text.Extra
+
+
+tests :: TestTree
+tests =
+    testGroup "Data.Text.ExtraTest"
+    [ testCase "when there is no span of the given character" $
+        longestSpanOf '*' "stars exist only where you believe"
+            |> assertEqual "" NoSpan
+    , testCase "when the given character is present" $
+        longestSpanOf '*' "it's here -> * <-"
+            |> assertEqual "" (Span 1)
+    , testCase "only counts the longest span" $
+        longestSpanOf '*' "it's here -> ** <-, not here: *"
+            |> assertEqual "" (Span 2)
+    ]

--- a/tests/Test.hs
+++ b/tests/Test.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import qualified Test.Property
 import qualified BoxTest
 import qualified CommonMarkTests
+import qualified Data.Text.ExtraTest
 import qualified ElmFormat.Render.ElmStructureTest
 import qualified Integration.CliTest
 import qualified Integration.LiteralTest
@@ -24,6 +25,7 @@ main =
         defaultMain $ testGroup "elm-format" $
             [ Test.Property.propertyTests
             , BoxTest.tests
+            , Data.Text.ExtraTest.tests
             , ElmFormat.Render.ElmStructureTest.tests
             , Integration.CliTest.tests
             , Integration.LiteralTest.tests

--- a/tests/test-files/good/Elm-0.18/AllSyntax/DocComments.elm
+++ b/tests/test-files/good/Elm-0.18/AllSyntax/DocComments.elm
@@ -51,6 +51,15 @@ Link with special characters: [Media\_features](https://developer.mozilla.org/en
 3.  Third
 
 
+# Code inlines
+
+Normal code inline: `word`
+
+Requires backtick escaping: `` `0` ``
+
+Requires multiple backticks for escaping: ``` code with `` ```
+
+
 # HTML blocks
 
 <strong>some HTML</strong>


### PR DESCRIPTION
…ectly