### PR TITLE
WIP: Parsec API for the new Elm parser

### DIFF
--- a/elm-format-lib/elm-format-lib.cabal
+++ b/elm-format-lib/elm-format-lib.cabal
@@ -118,6 +118,7 @@ library
         ElmVersion
         Parse.Markdown
         Reporting.Annotation
+        Reporting.Annotation.New
         Reporting.Error.Syntax
         Reporting.Region
         Reporting.Result
@@ -147,6 +148,7 @@ test-suite efl-tests
         ElmVersion
         Parse.Markdown
         Reporting.Annotation
+        Reporting.Annotation.New
         Reporting.Error.Syntax
         Reporting.Region
         Reporting.Result

--- a/elm-format-lib/src/Parse/IParser.hs
+++ b/elm-format-lib/src/Parse/IParser.hs
@@ -3,4 +3,4 @@ module Parse.IParser where
 import Text.Parsec.Prim (Parser)
 
 
-type IParser = Parser
+type IParser a = Parser a

--- a/elm-format-lib/src/Parse/Primitives.hs
+++ b/elm-format-lib/src/Parse/Primitives.hs
@@ -1,3 +1,6 @@
+-- This module is copied from the Elm compiler with small changes
+-- https://github.com/elm/compiler/blob/94715a520f499591ac6901c8c822bc87cd1af24f/compiler/src/Parse/Primitives.hs
+
 {-# OPTIONS_GHC -Wall -fno-warn-unused-do-bind -fno-warn-name-shadowing #-}
 {-# LANGUAGE BangPatterns, Rank2Types, UnboxedTuples #-}
 module Parse.Primitives

--- a/elm-format-lib/src/Parse/Primitives.hs
+++ b/elm-format-lib/src/Parse/Primitives.hs
@@ -1,8 +1,8 @@
 {-# OPTIONS_GHC -Wall -fno-warn-unused-do-bind -fno-warn-name-shadowing #-}
 {-# LANGUAGE BangPatterns, Rank2Types, UnboxedTuples #-}
 module Parse.Primitives
-  ( fromByteString
-  , Parser(..)
+  -- ( fromByteString
+  ( Parser(..)
   , State(..)
   , Row
   , Col
@@ -13,7 +13,7 @@ module Parse.Primitives
   , word1, word2
   , unsafeIndex, isWord, getCharWidth
   , Snippet(..)
-  , fromSnippet
+  -- , fromSnippet
   )
   where
 
@@ -54,6 +54,8 @@ data State = -- PERF try taking some out to avoid allocation
     , _indent :: !Word16
     , _row :: !Row
     , _col :: !Col
+    , _sourceName :: String
+    , _newline :: [Bool]
     }
 
 
@@ -135,7 +137,7 @@ oneOfHelp state cok eok cerr eerr toError parsers =
 
     [] ->
       let
-        (State _ _ _ _ row col) = state
+        (State _ _ _ _ row col _ _) = state
       in
       eerr row col toError
 
@@ -201,21 +203,21 @@ instance Monad (Parser x) where
 -- FROM BYTESTRING
 
 
-fromByteString :: Parser x a -> (Row -> Col -> x) -> B.ByteString -> Either x a
-fromByteString (Parser parser) toBadEnd (B.PS fptr offset length) =
-  B.accursedUnutterablePerformIO $
-    let
-      toOk' = toOk toBadEnd
-      !pos = plusPtr (unsafeForeignPtrToPtr fptr) offset
-      !end = plusPtr pos length
-      !result = parser (State fptr pos end 0 1 1) toOk' toOk' toErr toErr
-    in
-    do  touchForeignPtr fptr
-        return result
+--fromByteString :: Parser x a -> (Row -> Col -> x) -> B.ByteString -> Either x a
+--fromByteString (Parser parser) toBadEnd (B.PS fptr offset length) =
+--  B.accursedUnutterablePerformIO $
+--    let
+--      toOk' = toOk toBadEnd
+--      !pos = plusPtr (unsafeForeignPtrToPtr fptr) offset
+--      !end = plusPtr pos length
+--      !result = parser (State fptr pos end 0 1 1) toOk' toOk' toErr toErr
+--    in
+--    do  touchForeignPtr fptr
+--        return result
 
 
 toOk :: (Row -> Col -> x) -> a -> State -> Either x a
-toOk toBadEnd !a (State _ pos end _ row col) =
+toOk toBadEnd !a (State _ pos end _ row col _ _) =
   if pos == end
   then Right a
   else Left (toBadEnd row col)
@@ -240,17 +242,17 @@ data Snippet =
     }
 
 
-fromSnippet :: Parser x a -> (Row -> Col -> x) -> Snippet -> Either x a
-fromSnippet (Parser parser) toBadEnd (Snippet fptr offset length row col) =
-  B.accursedUnutterablePerformIO $
-    let
-      toOk' = toOk toBadEnd
-      !pos = plusPtr (unsafeForeignPtrToPtr fptr) offset
-      !end = plusPtr pos length
-      !result = parser (State fptr pos end 0 row col) toOk' toOk' toErr toErr
-    in
-    do  touchForeignPtr fptr
-        return result
+--fromSnippet :: Parser x a -> (Row -> Col -> x) -> Snippet -> Either x a
+--fromSnippet (Parser parser) toBadEnd (Snippet fptr offset length row col) =
+--  B.accursedUnutterablePerformIO $
+--    let
+--      toOk' = toOk toBadEnd
+--      !pos = plusPtr (unsafeForeignPtrToPtr fptr) offset
+--      !end = plusPtr pos length
+--      !result = parser (State fptr pos end 0 row col) toOk' toOk' toErr toErr
+--    in
+--    do  touchForeignPtr fptr
+--        return result
 
 
 
@@ -259,30 +261,30 @@ fromSnippet (Parser parser) toBadEnd (Snippet fptr offset length row col) =
 
 getCol :: Parser x Word16
 getCol =
-  Parser $ \state@(State _ _ _ _ _ col) _ eok _ _ ->
+  Parser $ \state@(State _ _ _ _ _ col _ _) _ eok _ _ ->
     eok col state
 
 
 {-# INLINE getPosition #-}
 getPosition :: Parser x A.Position
 getPosition =
-  Parser $ \state@(State _ _ _ _ row col) _ eok _ _ ->
+  Parser $ \state@(State _ _ _ _ row col _ _) _ eok _ _ ->
     eok (A.Position row col) state
 
 
 addLocation :: Parser x a -> Parser x (A.Located a)
 addLocation (Parser parser) =
-  Parser $ \state@(State _ _ _ _ sr sc) cok eok cerr eerr ->
+  Parser $ \state@(State _ _ _ _ sr sc _ _) cok eok cerr eerr ->
     let
-      cok' a s@(State _ _ _ _ er ec) = cok (A.At (A.Region (A.Position sr sc) (A.Position er ec)) a) s
-      eok' a s@(State _ _ _ _ er ec) = eok (A.At (A.Region (A.Position sr sc) (A.Position er ec)) a) s
+      cok' a s@(State _ _ _ _ er ec _ _) = cok (A.At (A.Region (A.Position sr sc) (A.Position er ec)) a) s
+      eok' a s@(State _ _ _ _ er ec _ _) = eok (A.At (A.Region (A.Position sr sc) (A.Position er ec)) a) s
     in
     parser state cok' eok' cerr eerr
 
 
 addEnd :: A.Position -> a -> Parser x (A.Located a)
 addEnd start value =
-  Parser $ \state@(State _ _ _ _ row col) _ eok _ _ ->
+  Parser $ \state@(State _ _ _ _ row col _ _) _ eok _ _ ->
     eok (A.at start (A.Position row col) value) state
 
 
@@ -292,37 +294,37 @@ addEnd start value =
 
 getIndent :: Parser x Word16
 getIndent =
-  Parser $ \state@(State _ _ _ indent _ _) _ eok _ _ ->
+  Parser $ \state@(State _ _ _ indent _ _ _ _) _ eok _ _ ->
     eok indent state
 
 
 setIndent :: Word16 -> Parser x ()
 setIndent indent =
-  Parser $ \(State src pos end _ row col) _ eok _ _ ->
+  Parser $ \(State src pos end _ row col sn nl) _ eok _ _ ->
     let
-      !newState = State src pos end indent row col
+      !newState = State src pos end indent row col sn nl
     in
     eok () newState
 
 
 withIndent :: Parser x a -> Parser x a
 withIndent (Parser parser) =
-  Parser $ \(State src pos end oldIndent row col) cok eok cerr eerr ->
+  Parser $ \(State src pos end oldIndent row col sn nl) cok eok cerr eerr ->
     let
-      cok' a (State s p e _ r c) = cok a (State s p e oldIndent r c)
-      eok' a (State s p e _ r c) = eok a (State s p e oldIndent r c)
+      cok' a (State s p e _ r c sn' nl') = cok a (State s p e oldIndent r c sn' nl')
+      eok' a (State s p e _ r c sn' nl') = eok a (State s p e oldIndent r c sn' nl')
     in
-    parser (State src pos end col row col) cok' eok' cerr eerr
+    parser (State src pos end col row col sn nl) cok' eok' cerr eerr
 
 
 withBacksetIndent :: Word16 -> Parser x a -> Parser x a
 withBacksetIndent backset (Parser parser) =
-  Parser $ \(State src pos end oldIndent row col) cok eok cerr eerr ->
+  Parser $ \(State src pos end oldIndent row col sn nl) cok eok cerr eerr ->
     let
-      cok' a (State s p e _ r c) = cok a (State s p e oldIndent r c)
-      eok' a (State s p e _ r c) = eok a (State s p e oldIndent r c)
+      cok' a (State s p e _ r c sn' nl') = cok a (State s p e oldIndent r c sn' nl')
+      eok' a (State s p e _ r c sn' nl') = eok a (State s p e oldIndent r c sn' nl')
     in
-    parser (State src pos end (col - backset) row col) cok' eok' cerr eerr
+    parser (State src pos end (col - backset) row col sn nl) cok' eok' cerr eerr
 
 
 
@@ -331,7 +333,7 @@ withBacksetIndent backset (Parser parser) =
 
 inContext :: (x -> Row -> Col -> y) -> Parser y start -> Parser x a -> Parser y a
 inContext addContext (Parser parserStart) (Parser parserA) =
-  Parser $ \state@(State _ _ _ _ row col) cok eok cerr eerr ->
+  Parser $ \state@(State _ _ _ _ row col _ _) cok eok cerr eerr ->
     let
       cerrA r c tx = cerr row col (addContext (tx r c))
       eerrA r c tx = eerr row col (addContext (tx r c))
@@ -344,7 +346,7 @@ inContext addContext (Parser parserStart) (Parser parserA) =
 
 specialize :: (x -> Row -> Col -> y) -> Parser x a -> Parser y a
 specialize addContext (Parser parser) =
-  Parser $ \state@(State _ _ _ _ row col) cok eok cerr eerr ->
+  Parser $ \state@(State _ _ _ _ row col _ _) cok eok cerr eerr ->
     let
       cerr' r c tx = cerr row col (addContext (tx r c))
       eerr' r c tx = eerr row col (addContext (tx r c))
@@ -358,9 +360,9 @@ specialize addContext (Parser parser) =
 
 word1 :: Word8 -> (Row -> Col -> x) -> Parser x ()
 word1 word toError =
-  Parser $ \(State src pos end indent row col) cok _ _ eerr ->
+  Parser $ \(State src pos end indent row col sn nl) cok _ _ eerr ->
     if pos < end && unsafeIndex pos == word then
-      let !newState = State src (plusPtr pos 1) end indent row (col + 1) in
+      let !newState = State src (plusPtr pos 1) end indent row (col + 1) sn nl in
       cok () newState
     else
       eerr row col toError
@@ -368,12 +370,12 @@ word1 word toError =
 
 word2 :: Word8 -> Word8 -> (Row -> Col -> x) -> Parser x ()
 word2 w1 w2 toError =
-  Parser $ \(State src pos end indent row col) cok _ _ eerr ->
+  Parser $ \(State src pos end indent row col sn nl) cok _ _ eerr ->
     let
       !pos1 = plusPtr pos 1
     in
     if pos1 < end && unsafeIndex pos == w1 && unsafeIndex pos1 == w2 then
-      let !newState = State src (plusPtr pos 2) end indent row (col + 2) in
+      let !newState = State src (plusPtr pos 2) end indent row (col + 2) sn nl in
       cok () newState
     else
       eerr row col toError

--- a/elm-format-lib/src/Reporting/Annotation/New.hs
+++ b/elm-format-lib/src/Reporting/Annotation/New.hs
@@ -1,3 +1,6 @@
+-- This module is copied from the Elm compiler with small changes
+-- https://github.com/elm/compiler/blob/94715a520f499591ac6901c8c822bc87cd1af24f/compiler/src/Reporting/Annotation.hs
+
 {-# OPTIONS_GHC -Wall #-}
 module Reporting.Annotation.New
   ( Located(..)

--- a/elm-format-lib/src/Text/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/Parsec/Char.hs
@@ -16,7 +16,16 @@ module Text.Parsec.Char
   , string
   ) where
 
-import Text.Parsec.Prim (Parser)
+import qualified Parse.Primitives as EP
+import Text.Parsec.Prim (Parser(..))
+import Text.Parsec.Pos (newPos)
+import Text.Parsec.Error (Message(SysUnExpect, Expect), newErrorMessage, setErrorMessage)
+
+import Foreign.Ptr (plusPtr)
+import Data.Bits ((.|.), (.&.), shiftL, shiftR)
+import Data.Word (Word8)
+import Data.Char (chr, ord)
+
 
 oneOf :: [Char] -> Parser Char
 oneOf = undefined
@@ -54,5 +63,120 @@ anyChar             = satisfy (const True)
 satisfy :: (Char -> Bool) -> Parser Char
 satisfy = undefined
 
+
 string :: String -> Parser String
-string = undefined
+string = fmap decode . word8s . concatMap encodeChar
+
+
+word8s :: [Word8] -> Parser [Word8]
+word8s [] = return []
+word8s (w:ws) =
+  Parser $ EP.Parser $ \s@(EP.State _ pos end _ row col) cok _ cerr eerr ->
+    let
+      sourcePos = newPos "TODO - SourceName" row col
+
+      errEof _ _ = setErrorMessage (Expect (show (w:ws)))
+                    (newErrorMessage (SysUnExpect "") sourcePos)
+
+      errExpect x _ _ = setErrorMessage (Expect (show (w:ws)))
+                          (newErrorMessage (SysUnExpect (show x)) sourcePos)
+
+      walk [] s' = cok (w:ws) s'
+      walk (w':ws') s'@(EP.State _ pos' _ _ row' col') =
+        if pos' == end then
+          cerr row col errEof
+        else if EP.unsafeIndex pos' == w' then
+          walk ws' (updatePos w' s')
+        else
+          cerr row col (errExpect w')
+    in
+    if pos == end then
+      eerr row col errEof
+    else if EP.unsafeIndex pos == w then
+        walk ws (updatePos w s)
+    else
+      eerr row col (errExpect w)
+
+
+updatePos :: Word8 -> EP.State -> EP.State
+updatePos w (EP.State src pos end indent row col) =
+  let
+    (row', col') =
+      case w of
+        0x0a {- "\n" -} -> (row + 1, 1)
+
+        -- The doccumentation for `Text.Parsec.Char.updatePosChar` claims that
+        -- carrige return ("\r") increments row by 1, just like newline ("\n").
+        -- This doesn't appear to be the case from looking at the code:
+        -- https://hackage.haskell.org/package/parsec-3.1.14.0/docs/src/Text.Parsec.Pos.html#updatePosChar
+        --
+        -- Let's not devle into this unless it turns out that elm-format
+        -- needs it.
+        0x0d {- "\r" -} -> error "Can't handle carrige return"
+
+        -- The parsec behaviour for tabs is to increment to the nearest
+        -- 8'th collumn. Shoud we do this as well?
+        -- Let's not implement this unless it turns out that elm-format
+        -- needs it.
+        0x09 {- "\t" -} -> error "Can't handle tabs"
+
+        _ -> (row, col + 1)
+  in
+  EP.State src (plusPtr pos 1) end indent row' col'
+
+
+-- https://hackage.haskell.org/package/utf8-string-1.0.2/docs/src/Codec.Binary.UTF8.String.html#encodeChar
+encodeChar :: Char -> [Word8]
+encodeChar = map fromIntegral . go . ord
+ where
+  go oc
+   | oc <= 0x7f       = [oc]
+
+   | oc <= 0x7ff      = [ 0xc0 + (oc `shiftR` 6)
+                        , 0x80 + oc .&. 0x3f
+                        ]
+
+   | oc <= 0xffff     = [ 0xe0 + (oc `shiftR` 12)
+                        , 0x80 + ((oc `shiftR` 6) .&. 0x3f)
+                        , 0x80 + oc .&. 0x3f
+                        ]
+
+
+-- https://hackage.haskell.org/package/utf8-string-1.0.2/docs/src/Codec.Binary.UTF8.String.html#decode
+decode :: [Word8] -> String
+decode [    ] = ""
+decode (c:cs)
+  | c < 0x80  = chr (fromEnum c) : decode cs
+  | c < 0xc0  = replacement_character : decode cs
+  | c < 0xe0  = multi1
+  | c < 0xf0  = multi_byte 2 0xf  0x800
+  | c < 0xf8  = multi_byte 3 0x7  0x10000
+  | c < 0xfc  = multi_byte 4 0x3  0x200000
+  | c < 0xfe  = multi_byte 5 0x1  0x4000000
+  | otherwise = replacement_character : decode cs
+  where
+    multi1 = case cs of
+      c1 : ds | c1 .&. 0xc0 == 0x80 ->
+        let d = ((fromEnum c .&. 0x1f) `shiftL` 6) .|.  fromEnum (c1 .&. 0x3f)
+        in if d >= 0x000080 then toEnum d : decode ds
+                            else replacement_character : decode ds
+      _ -> replacement_character : decode cs
+
+    multi_byte :: Int -> Word8 -> Int -> [Char]
+    multi_byte i mask overlong = aux i cs (fromEnum (c .&. mask))
+      where
+        aux 0 rs acc
+          | overlong <= acc && acc <= 0x10ffff &&
+            (acc < 0xd800 || 0xdfff < acc)     &&
+            (acc < 0xfffe || 0xffff < acc)      = chr acc : decode rs
+          | otherwise = replacement_character : decode rs
+
+        aux n (r:rs) acc
+          | r .&. 0xc0 == 0x80 = aux (n-1) rs
+                               $ shiftL acc 6 .|. fromEnum (r .&. 0x3f)
+
+        aux _ rs     _ = replacement_character : decode rs
+
+
+replacement_character :: Char
+replacement_character = '\xfffd'

--- a/elm-format-lib/src/Text/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/Parsec/Char.hs
@@ -26,8 +26,6 @@ import Data.Word (Word8)
 import Data.Char (chr, ord)
 import qualified Data.Char as C
 
-import Debug.Trace (trace)
-
 
 oneOf :: [Char] -> Parser Char
 oneOf cs = satisfy (\c -> elem c cs)
@@ -42,7 +40,7 @@ upper = satisfy C.isUpper <?> "uppercase letter"
 
 
 lower :: Parser Char
-lower = satisfy C.isUpper <?> "lowercase letter"
+lower = satisfy C.isLower <?> "lowercase letter"
 
 
 alphaNum :: Parser Char
@@ -75,13 +73,13 @@ anyChar = satisfy (const True)
 
 satisfy :: (Char -> Bool) -> Parser Char
 satisfy f =
-  EP.Parser $ \s@(EP.State _ pos end _ row col _ _) cok _ _ eerr ->
+  EP.Parser $ \s@(EP.State _ pos end _ row col sourceName _) cok _ _ eerr ->
     let
       w = EP.unsafeIndex pos
 
-      errEof = newErrorMessage (SysUnExpect "") "TODO"
+      errEof = newErrorMessage (SysUnExpect "") sourceName
 
-      errExpect = newErrorMessage (SysUnExpect $ show w) "TODO"
+      errExpect = newErrorMessage (SysUnExpect $ show w) sourceName
     in
     if pos == end then
       eerr row col errEof
@@ -117,13 +115,13 @@ stringHelp :: forall b.
   -> (Row -> Col -> (Row -> Col -> ParseError) -> b)
   -> b
 stringHelp "" s toOk _ = toOk s
-stringHelp (c:cs) s@(EP.State _ pos end _ row col _ _) toOk toError =
+stringHelp (c:cs) s@(EP.State _ pos end _ row col sourceName _) toOk toError =
   let
     errEof _ _ = setErrorMessage (Expect (show (c:cs)))
-                  (newErrorMessage (SysUnExpect "") "TODO" row col)
+                  (newErrorMessage (SysUnExpect "") sourceName row col)
 
     errExpect x _ _ = setErrorMessage (Expect (show (c:cs)))
-                        (newErrorMessage (SysUnExpect (show x)) "TODO" row col)
+                        (newErrorMessage (SysUnExpect (show x)) sourceName row col)
 
     w = EP.unsafeIndex pos
   in

--- a/elm-format-lib/src/Text/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/Parsec/Char.hs
@@ -139,14 +139,13 @@ updatePos width c (EP.State src pos end indent row col sourceName newline) =
       case c of
         '\n' -> (row + 1, 1)
 
-        -- The doccumentation for `Text.Parsec.Char.updatePosChar` claims that
-        -- carrige return ("\r") increments row by 1, just like newline ("\n").
-        -- This doesn't appear to be the case from looking at the code:
-        -- https://hackage.haskell.org/package/parsec-3.1.14.0/docs/src/Text.Parsec.Pos.html#updatePosChar
+        -- The parsec docs states that CR increments line just like an LF does,
+        -- this is not what happens in the code though,
+        -- see: https://github.com/haskell/parsec/issues/129 for details.
         --
-        -- Let's not devle into this unless it turns out that elm-format
-        -- needs it.
-        '\r' -> error "Can't handle carrige return"
+        -- Here we've opted for following the behaviour of parsec, and not the
+        -- doccumentation even though this behaviour might be considered a bug.
+        '\r' -> (row, col + 1)
 
         -- The parsec behaviour for tabs is to increment to the nearest
         -- 8'th collumn. Shoud we do this as well?

--- a/elm-format-lib/src/Text/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/Parsec/Char.hs
@@ -73,13 +73,11 @@ word8s [] = return []
 word8s (w:ws) =
   Parser $ EP.Parser $ \s@(EP.State _ pos end _ row col) cok _ cerr eerr ->
     let
-      sourcePos = newPos "TODO - SourceName" row col
-
       errEof _ _ = setErrorMessage (Expect (show (w:ws)))
-                    (newErrorMessage (SysUnExpect "") sourcePos)
+                    (newErrorMessage (SysUnExpect "") "TODO" row col)
 
       errExpect x _ _ = setErrorMessage (Expect (show (w:ws)))
-                          (newErrorMessage (SysUnExpect (show x)) sourcePos)
+                          (newErrorMessage (SysUnExpect (show x)) "TODO" row col)
 
       walk [] s' = cok (w:ws) s'
       walk (w':ws') s'@(EP.State _ pos' _ _ row' col') =

--- a/elm-format-lib/src/Text/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/Parsec/Char.hs
@@ -26,6 +26,8 @@ import Data.Word (Word8)
 import Data.Char (chr, ord)
 import qualified Data.Char as C
 
+import Debug.Trace (trace)
+
 
 oneOf :: [Char] -> Parser Char
 oneOf cs = satisfy (\c -> elem c cs)
@@ -93,10 +95,10 @@ satisfy f =
 
 string :: String -> Parser String
 string "" = return ""
-string match@(_:cs) =
+string match@(c:cs) =
   EP.Parser $ \s cok _ cerr eerr ->
     stringHelp
-      match
+      [c]
       s
       (\s' ->
         stringHelp

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -11,14 +11,17 @@ module Text.Parsec.Combinator
   , eof
   ) where
 
-import Text.Parsec.Prim (Parser, (<|>))
+import Text.Parsec.Prim (Parser, (<|>), many)
 
 
 choice :: [Parser a] -> Parser a
 choice = undefined
 
 many1 :: Parser a -> Parser [a]
-many1 = undefined
+many1 p =
+  do  x <- p
+      xs <- many p
+      return (x:xs)
 
 manyTill :: Parser a -> Parser end -> Parser [a]
 manyTill = undefined

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -28,8 +28,15 @@ many1 p =
       xs <- many p
       return (x:xs)
 
+
 manyTill :: Parser a -> Parser end -> Parser [a]
-manyTill = undefined
+manyTill p end =
+  scan
+  where
+    scan =
+      do{ _ <- end; return [] }
+      <|>
+      do{ x <- p; xs <- scan; return (x:xs) }
 
 skipMany1 :: Parser a -> Parser ()
 skipMany1 = undefined

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -15,9 +15,12 @@ import qualified Parse.Primitives as EP
 import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many)
 import Text.Parsec.Error (Message(UnExpect), newErrorMessage)
 
+import Control.Monad (mzero)
+
 
 choice :: [Parser a] -> Parser a
-choice = undefined
+choice ps = foldr (<|>) mzero ps
+
 
 many1 :: Parser a -> Parser [a]
 many1 p =

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -15,7 +15,7 @@ import qualified Parse.Primitives as EP
 import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many)
 import Text.Parsec.Error (Message(UnExpect), newErrorMessage)
 
-import Control.Monad (mzero)
+import Control.Monad (mzero, liftM)
 
 
 choice :: [Parser a] -> Parser a
@@ -38,7 +38,7 @@ option :: a -> Parser a -> Parser a
 option x p = p <|> return x
 
 optionMaybe :: Parser a -> Parser (Maybe a)
-optionMaybe = undefined
+optionMaybe p = option Nothing (liftM Just p)
 
 anyToken :: Parser Char
 anyToken = undefined

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -42,4 +42,4 @@ between :: Parser open -> Parser close -> Parser a -> Parser a
 between = undefined
 
 eof :: Parser ()
-eof = undefined
+eof = return ()

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -12,7 +12,7 @@ module Text.Parsec.Combinator
   ) where
 
 import qualified Parse.Primitives as EP
-import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many)
+import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many, skipMany)
 import Text.Parsec.Error (Message(UnExpect), newErrorMessage)
 
 import Control.Monad (mzero, liftM)
@@ -39,7 +39,9 @@ manyTill p end =
       do{ x <- p; xs <- scan; return (x:xs) }
 
 skipMany1 :: Parser a -> Parser ()
-skipMany1 = undefined
+skipMany1 p =
+  do  _ <- p
+      skipMany p
 
 option :: a -> Parser a -> Parser a
 option x p = p <|> return x

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -11,7 +11,8 @@ module Text.Parsec.Combinator
   , eof
   ) where
 
-import Text.Parsec.Prim (Parser)
+import Text.Parsec.Prim (Parser, (<|>))
+
 
 choice :: [Parser a] -> Parser a
 choice = undefined
@@ -26,7 +27,7 @@ skipMany1 :: Parser a -> Parser ()
 skipMany1 = undefined
 
 option :: a -> Parser a -> Parser a
-option = undefined
+option x p = p <|> return x
 
 optionMaybe :: Parser a -> Parser (Maybe a)
 optionMaybe = undefined

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -11,7 +11,9 @@ module Text.Parsec.Combinator
   , eof
   ) where
 
-import Text.Parsec.Prim (Parser, (<|>), many)
+import qualified Parse.Primitives as EP
+import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many)
+import Text.Parsec.Error (Message(UnExpect), newErrorMessage)
 
 
 choice :: [Parser a] -> Parser a
@@ -38,8 +40,11 @@ optionMaybe = undefined
 anyToken :: Parser Char
 anyToken = undefined
 
+
 notFollowedBy :: Show a => Parser a -> Parser ()
-notFollowedBy = undefined
+notFollowedBy p =
+  try $ do{ c <- try p; unexpected (show c) } <|> return ()
+
 
 between :: Parser open -> Parser close -> Parser a -> Parser a
 between = undefined

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -57,7 +57,8 @@ notFollowedBy p =
 
 
 between :: Parser open -> Parser close -> Parser a -> Parser a
-between = undefined
+between open close p =
+  do{ _ <- open; x <- p; _ <- close; return x }
 
 eof :: Parser ()
 eof = return ()

--- a/elm-format-lib/src/Text/Parsec/Error.hs
+++ b/elm-format-lib/src/Text/Parsec/Error.hs
@@ -1,6 +1,7 @@
 module Text.Parsec.Error
   ( Message
   , ParseError
+  , newErrorUnknown
   , errorPos
   , errorMessages
   ) where
@@ -43,6 +44,11 @@ messageString (Message     s) = s
 
 
 data ParseError = ParseError !SourcePos [Message]
+
+
+newErrorUnknown :: SourcePos -> ParseError
+newErrorUnknown pos
+    = ParseError pos []
 
 
 errorPos :: ParseError -> SourcePos

--- a/elm-format-lib/src/Text/Parsec/Error.hs
+++ b/elm-format-lib/src/Text/Parsec/Error.hs
@@ -1,9 +1,11 @@
 module Text.Parsec.Error
-  ( Message
+  ( Message(..)
   , ParseError
   , newErrorUnknown
   , errorPos
   , errorMessages
+  , newErrorMessage
+  , setErrorMessage
   ) where
 
 import Data.List (nub, sort)
@@ -56,6 +58,20 @@ errorPos = undefined
 
 errorMessages :: ParseError -> [Message]
 errorMessages = undefined
+
+
+
+-- Create parse errors
+
+
+newErrorMessage :: Message -> SourcePos -> ParseError
+newErrorMessage msg pos
+    = ParseError pos [msg]
+
+
+setErrorMessage :: Message -> ParseError -> ParseError
+setErrorMessage msg (ParseError pos msgs)
+    = ParseError pos (msg : filter (msg /=) msgs)
 
 
 instance Show ParseError where

--- a/elm-format-lib/src/Text/Parsec/Error.hs
+++ b/elm-format-lib/src/Text/Parsec/Error.hs
@@ -1,16 +1,17 @@
 module Text.Parsec.Error
   ( Message(..)
   , ParseError
+  , newErrorMessage
   , newErrorUnknown
   , errorPos
   , errorMessages
-  , newErrorMessage
   , setErrorMessage
   ) where
 
 import Data.List (nub, sort)
 import Data.Typeable (Typeable)
 
+import Parse.Primitives (Row, Col)
 import Text.Parsec.Pos (SourcePos)
 
 
@@ -45,12 +46,7 @@ messageString (Expect      s) = s
 messageString (Message     s) = s
 
 
-data ParseError = ParseError !SourcePos [Message]
-
-
-newErrorUnknown :: SourcePos -> ParseError
-newErrorUnknown pos
-    = ParseError pos []
+data ParseError = ParseError String Row Col [Message]
 
 
 errorPos :: ParseError -> SourcePos
@@ -64,14 +60,19 @@ errorMessages = undefined
 -- Create parse errors
 
 
-newErrorMessage :: Message -> SourcePos -> ParseError
-newErrorMessage msg pos
-    = ParseError pos [msg]
+newErrorMessage :: Message -> String -> Row -> Col -> ParseError
+newErrorMessage msg sourceName row col
+    = ParseError sourceName row col [msg]
+
+
+newErrorUnknown :: String -> Row -> Col -> ParseError
+newErrorUnknown sourceName row col
+    = ParseError sourceName row col []
 
 
 setErrorMessage :: Message -> ParseError -> ParseError
-setErrorMessage msg (ParseError pos msgs)
-    = ParseError pos (msg : filter (msg /=) msgs)
+setErrorMessage msg (ParseError sourceName row col msgs)
+    = ParseError sourceName row col (msg : filter (msg /=) msgs)
 
 
 instance Show ParseError where

--- a/elm-format-lib/src/Text/Parsec/Error.hs
+++ b/elm-format-lib/src/Text/Parsec/Error.hs
@@ -1,3 +1,5 @@
+-- Large parts of this module are copied from https://hackage.haskell.org/package/parsec-3.1.14.0/docs/src/Text.Parsec.Error.html#messageString
+
 module Text.Parsec.Error
   ( Message(..)
   , ParseError
@@ -12,7 +14,7 @@ import Data.List (nub, sort)
 import Data.Typeable (Typeable)
 
 import Parse.Primitives (Row, Col)
-import Text.Parsec.Pos (SourcePos)
+import Text.Parsec.Pos (SourcePos, newPos)
 
 
 data Message
@@ -50,10 +52,11 @@ data ParseError = ParseError String Row Col [Message]
 
 
 errorPos :: ParseError -> SourcePos
-errorPos = undefined
+errorPos (ParseError sourceName row col _) = newPos sourceName row col
+
 
 errorMessages :: ParseError -> [Message]
-errorMessages = undefined
+errorMessages (ParseError _ _ _ messages) = messages
 
 
 

--- a/elm-format-lib/src/Text/Parsec/Error.hs
+++ b/elm-format-lib/src/Text/Parsec/Error.hs
@@ -8,6 +8,7 @@ module Text.Parsec.Error
   , errorPos
   , errorMessages
   , setErrorMessage
+  , mergeError
   ) where
 
 import Data.List (nub, sort)
@@ -76,6 +77,19 @@ newErrorUnknown sourceName row col
 setErrorMessage :: Message -> ParseError -> ParseError
 setErrorMessage msg (ParseError sourceName row col msgs)
     = ParseError sourceName row col (msg : filter (msg /=) msgs)
+
+
+mergeError :: ParseError -> ParseError -> ParseError
+mergeError e1@(ParseError sn1 r1 c1 msgs1) e2@(ParseError sn2 r2 c2 msgs2)
+    -- prefer meaningful errors
+    | null msgs2 && not (null msgs1) = e1
+    | null msgs1 && not (null msgs2) = e2
+    | otherwise
+    = case (r1, c1) `compare` (r2, c2) of
+        -- select the longest match
+        EQ -> ParseError sn1 r1 c1 (msgs1 ++ msgs2)
+        GT -> e1
+        LT -> e2
 
 
 instance Show ParseError where

--- a/elm-format-lib/src/Text/Parsec/Indent.hs
+++ b/elm-format-lib/src/Text/Parsec/Indent.hs
@@ -9,6 +9,7 @@ module Text.Parsec.Indent
   ) where
 
 import Text.Parsec.Prim (Parser, getParserState, updateParserState)
+import Text.Parsec.Combinator (many1)
 import qualified Parse.Primitives as EP
 
 
@@ -17,7 +18,9 @@ runIndent _ = id
 
 
 block :: Parser a -> Parser [a]
-block = undefined
+block p = withPos $ do
+    r <- many1 (checkIndent >> p)
+    return r
 
 
 indented :: Parser ()

--- a/elm-format-lib/src/Text/Parsec/Indent.hs
+++ b/elm-format-lib/src/Text/Parsec/Indent.hs
@@ -1,32 +1,31 @@
 {-# LANGUAGE FlexibleContexts #-}
 
 module Text.Parsec.Indent
-  ( IndentParser
-  , runIndent
+  ( runIndent
   , block
   , indented
   , checkIndent
   , withPos
   ) where
 
-import Text.Parsec.Pos (SourcePos, SourceName)
 import Text.Parsec.Prim (Parser)
 
-import Control.Monad.State (State)
 
-type IndentParser a = Parser a
+runIndent :: s -> a -> a
+runIndent _ = id
 
-runIndent :: SourceName -> State SourcePos a -> a
-runIndent = undefined
 
-block :: IndentParser a -> IndentParser [a]
+block :: Parser a -> Parser [a]
 block = undefined
 
-indented :: IndentParser ()
+
+indented :: Parser ()
 indented = undefined
 
-checkIndent :: IndentParser ()
+
+checkIndent :: Parser ()
 checkIndent = undefined
 
-withPos :: IndentParser a -> IndentParser a
+
+withPos :: Parser a -> Parser a
 withPos = undefined

--- a/elm-format-lib/src/Text/Parsec/Indent.hs
+++ b/elm-format-lib/src/Text/Parsec/Indent.hs
@@ -27,7 +27,9 @@ indented =
 
 
 checkIndent :: Parser ()
-checkIndent = undefined
+checkIndent =
+  do  (EP.State _ _ _ indent _ col _ _) <- getParserState
+      if indent == col then return () else fail "indentation doesn't match"
 
 
 withPos :: Parser a -> Parser a

--- a/elm-format-lib/src/Text/Parsec/Indent.hs
+++ b/elm-format-lib/src/Text/Parsec/Indent.hs
@@ -8,7 +8,7 @@ module Text.Parsec.Indent
   , withPos
   ) where
 
-import Text.Parsec.Prim (Parser, updateParserState)
+import Text.Parsec.Prim (Parser, getParserState, updateParserState)
 import qualified Parse.Primitives as EP
 
 
@@ -21,7 +21,9 @@ block = undefined
 
 
 indented :: Parser ()
-indented = undefined
+indented =
+  do  (EP.State _ _ _ indent _ col _ _) <- getParserState
+      if col <= indent then fail "not indented" else do return ()
 
 
 checkIndent :: Parser ()

--- a/elm-format-lib/src/Text/Parsec/Indent.hs
+++ b/elm-format-lib/src/Text/Parsec/Indent.hs
@@ -8,7 +8,8 @@ module Text.Parsec.Indent
   , withPos
   ) where
 
-import Text.Parsec.Prim (Parser)
+import Text.Parsec.Prim (Parser, updateParserState)
+import qualified Parse.Primitives as EP
 
 
 runIndent :: s -> a -> a
@@ -28,4 +29,6 @@ checkIndent = undefined
 
 
 withPos :: Parser a -> Parser a
-withPos = undefined
+withPos p =
+  do  updateParserState (\(EP.State s p e _ r c sn nl) -> EP.State s p e c r c sn nl)
+      p

--- a/elm-format-lib/src/Text/Parsec/Pos.hs
+++ b/elm-format-lib/src/Text/Parsec/Pos.hs
@@ -1,6 +1,7 @@
 module Text.Parsec.Pos
   ( SourceName
   , SourcePos
+  , newPos
   , sourceLine
   , sourceColumn
   ) where
@@ -12,6 +13,11 @@ type SourceName = String
 
 
 data SourcePos = SourcePos SourceName !EP.Row !EP.Col
+
+
+newPos :: String -> EP.Row -> EP.Col -> SourcePos
+newPos =
+  SourcePos
 
 
 sourceLine :: SourcePos -> Int

--- a/elm-format-lib/src/Text/Parsec/Pos.hs
+++ b/elm-format-lib/src/Text/Parsec/Pos.hs
@@ -15,7 +15,7 @@ type SourceName = String
 data SourcePos = SourcePos SourceName !EP.Row !EP.Col
 
 
-newPos :: String -> EP.Row -> EP.Col -> SourcePos
+newPos :: SourceName -> EP.Row -> EP.Col -> SourcePos
 newPos =
   SourcePos
 

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -105,7 +105,7 @@ infix  0 <?>
 
 
 (<?>) :: Parser a -> String -> Parser a
-(<?>) = undefined
+(<?>) p _ = p
 
 
 lookAhead :: Parser a -> Parser a

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE BangPatterns #-}
 
 module Text.Parsec.Prim
-  ( Parser
+  ( Parser(..)
   , (<?>)
   , (<|>)
   , lookAhead

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE BangPatterns #-}
 
 module Text.Parsec.Prim
   ( Parser
@@ -25,11 +26,21 @@ import qualified Control.Monad.Fail as Fail
 
 import Text.Parsec.Pos (SourceName, SourcePos, newPos)
 import Text.Parsec.Error (ParseError)
+import qualified Text.Parsec.Error as Error
 
 import qualified Parse.Primitives as EP
 import Parse.State (State)
 
-import qualified Text.Parsec.Error as Error
+import Data.Bits (shiftR, (.&.))
+import Data.Word (Word8)
+import Data.Char (ord)
+
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Internal as B
+import Foreign.Ptr (Ptr, plusPtr)
+import Foreign.Storable (peek)
+import Foreign.ForeignPtr (ForeignPtr, touchForeignPtr)
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 
 
 unknownError :: EP.Row -> EP.Col -> ParseError
@@ -106,22 +117,68 @@ try (Parser (EP.Parser parser)) =
   Parser $ EP.Parser $ \s cok eok _ err ->
     parser s cok eok err err
 
+
 many :: Parser a -> Parser [a]
 many = undefined
 
 skipMany ::Parser a -> Parser ()
 skipMany = undefined
 
-runParserT :: Parser a -> u -> SourceName -> s -> m (Either ParseError a)
-runParserT = undefined
+runParserT :: Parser a -> State -> SourceName -> String -> Either ParseError a
+runParserT (Parser (EP.Parser p)) _ name source =
+  B.accursedUnutterablePerformIO $
+    let
+      (B.PS fptr offset length) = stringToByteString source
+      !pos = plusPtr (unsafeForeignPtrToPtr fptr) offset
+      !end = plusPtr pos length
+      !result = p (EP.State fptr pos end 0 1 1) toOk toOk toErr toErr
+    in
+    do  touchForeignPtr fptr
+        return result
+
+
+toOk :: a -> EP.State -> Either x a
+toOk !a _ =
+  Right a
+
+
+toErr :: EP.Row -> EP.Col -> (EP.Row -> EP.Col -> x) -> Either x a
+toErr row col toError =
+  Left (toError row col)
+
+
+stringToByteString :: String -> B.ByteString
+stringToByteString = B.pack . concatMap encodeChar
+
+-- https://hackage.haskell.org/package/utf8-string-1.0.2/docs/src/Codec.Binary.UTF8.String.html#encodeChar
+encodeChar :: Char -> [Word8]
+encodeChar = map fromIntegral . go . ord
+ where
+  go oc
+   | oc <= 0x7f       = [oc]
+
+   | oc <= 0x7ff      = [ 0xc0 + (oc `shiftR` 6)
+                        , 0x80 + oc .&. 0x3f
+                        ]
+
+   | oc <= 0xffff     = [ 0xe0 + (oc `shiftR` 12)
+                        , 0x80 + ((oc `shiftR` 6) .&. 0x3f)
+                        , 0x80 + oc .&. 0x3f
+                        ]
+
+   | otherwise        = [ 0xf0 + (oc `shiftR` 18)
+                        , 0x80 + ((oc `shiftR` 12) .&. 0x3f)
+                        , 0x80 + ((oc `shiftR` 6) .&. 0x3f)
+                        , 0x80 + oc .&. 0x3f
+                        ]
 
 getPosition :: Parser SourcePos
 getPosition = undefined
 
-getInput :: Parser s
+getInput :: Parser String
 getInput = undefined
 
-setInput :: s -> Parser ()
+setInput :: String -> Parser ()
 setInput = undefined
 
 getState :: Parser State

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -20,6 +20,7 @@ module Text.Parsec.Prim
   , setInput
   , getState
   , updateState
+  , getParserState
   , updateParserState
   ) where
 

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -119,7 +119,30 @@ try (Parser (EP.Parser parser)) =
 
 
 many :: Parser a -> Parser [a]
-many = undefined
+many (Parser (EP.Parser p)) =
+  Parser $ EP.Parser $ \s cok eok cerr eerr ->
+    let
+      many_ p' acc x s' =
+        p
+          s'
+          (many_ p' (x:acc))
+          parserDoesNotConsumeErr
+          cerr
+          (\_ _ _ -> cok (reverse (x:acc)) s')
+    in
+    p
+      s
+      (many_ (EP.Parser p) [])
+      parserDoesNotConsumeErr
+      cerr
+      (\_ _ _ -> eok [] s)
+
+
+{-
+ - Whenever `many` is used with a parser that succeeds without consuming any input, this error is given. But since we expect elm-format to use `many` correctly this error can be left undefined.
+ -}
+parserDoesNotConsumeErr = undefined
+
 
 skipMany ::Parser a -> Parser ()
 skipMany = undefined

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -20,6 +20,7 @@ module Text.Parsec.Prim
   , setInput
   , getState
   , updateState
+  , updateParserState
   ) where
 
 import qualified Control.Applicative as Applicative ( Applicative(..), Alternative(..) )

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -146,10 +146,9 @@ many (Parser (EP.Parser p)) =
       (\_ _ _ -> eok [] s)
 
 
-{-
- - Whenever `many` is used with a parser that succeeds without consuming any input, this error is given. But since we expect elm-format to use `many` correctly this error can be left undefined.
- -}
-parserDoesNotConsumeErr = undefined
+-- Note that causing a runtime crash when using `many` with a parser that does
+-- not consume is the same behaviour as it was with parsec
+parserDoesNotConsumeErr = error "Text.Parsec.Prim.many: combinator 'many' is applied to a parser that accepts an empty string."
 
 
 skipMany ::Parser a -> Parser ()

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -138,17 +138,17 @@ many :: Parser a -> Parser [a]
 many (EP.Parser p) =
   EP.Parser $ \s cok eok cerr eerr ->
     let
-      many_ p' acc x s' =
+      many_ acc x s' =
         p
           s'
-          (many_ p' (x:acc))
+          (many_ (x:acc))
           parserDoesNotConsumeErr
           cerr
           (\_ _ _ -> cok (reverse (x:acc)) s')
     in
     p
       s
-      (many_ (EP.Parser p) [])
+      (many_ [])
       parserDoesNotConsumeErr
       cerr
       (\_ _ _ -> eok [] s)

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -66,7 +66,13 @@ instance Applicative.Alternative (EP.Parser ParseError) where
 
 
 instance Fail.MonadFail (EP.Parser ParseError) where
-    fail = undefined
+    fail = parserFail
+
+
+parserFail :: String -> Parser a
+parserFail msg =
+  EP.Parser $ \(EP.State _ _ _ _ row col sourceName _) _ _ _ eerr ->
+    eerr row col $ Error.newErrorMessage (Error.Message msg) sourceName
 
 
 instance MonadPlus (EP.Parser ParseError) where

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -101,8 +101,12 @@ infix  0 <?>
 
 
 lookAhead :: Parser a -> Parser a
-lookAhead = undefined
-
+lookAhead (EP.Parser p) =
+    EP.Parser $ \s _ eok cerr eerr ->
+      let
+        eok' a _ = eok a s
+      in
+      p s eok' eok' cerr eerr
 
 try :: Parser a -> Parser a
 try (EP.Parser parser) =

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -5,7 +5,8 @@
 {-# LANGUAGE BangPatterns #-}
 
 module Text.Parsec.Prim
-  ( Parser(..)
+  ( unexpected
+  , Parser(..)
   , (<?>)
   , (<|>)
   , lookAhead
@@ -45,7 +46,14 @@ import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 
 unknownError :: EP.Row -> EP.Col -> ParseError
 unknownError row col =
-  Error.newErrorUnknown $ newPos "" row col
+  Error.newErrorUnknown "" row col
+
+
+unexpected :: String -> Parser a
+unexpected msg
+    = Parser $ EP.Parser $ \(EP.State _ _ _ _ row col) _ _ _ eerr ->
+      eerr row col (Error.newErrorMessage (Error.UnExpect msg) "TODO")
+
 
 
 data Parser a

--- a/elm-format-lib/src/Text/ParserCombinators/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/ParserCombinators/Parsec/Char.hs
@@ -1,3 +1,5 @@
 module Text.ParserCombinators.Parsec.Char (lower) where
 
-lower = undefined
+import qualified Text.Parsec.Char
+
+lower = Text.Parsec.Char.lower

--- a/elm-format-lib/src/Text/ParserCombinators/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/ParserCombinators/Parsec/Combinator.hs
@@ -1,3 +1,5 @@
 module Text.ParserCombinators.Parsec.Combinator (eof) where
 
-eof = undefined
+import qualified Text.Parsec.Combinator
+
+eof = Text.Parsec.Combinator.eof

--- a/new-parser-2021-notes.md
+++ b/new-parser-2021-notes.md
@@ -58,7 +58,7 @@ All this said, I think we can start to think about what we want to do with our t
 * `Text.Parsec.Combinator`
     Almost all of the functions in this module are implemented in terms of functions found in `Text.Parsec.Prim`, and as such most of the functions are implemented exactly as they where by parserc (except for formatting changes). Only functions that somehow differ from the implementetion in parsec are listed.
 
-    * `eof`. Dummy implementation.
+    * `eof`. Not implemented the way parser does it. Implemented in a way that's more straightforward with the new parser. The error message is less descriptive.
 
         The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. parsec however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 

--- a/new-parser-2021-notes.md
+++ b/new-parser-2021-notes.md
@@ -1,10 +1,16 @@
 # GSOC Notes
 
+## About this document
+
+Here are various notes I (`@emmabastas`) have made during the effort to integrate the parser from the Elm compiler into elm-format as part of a [GSOC project](https://github.com/elm-tooling/gsoc-projects/issues/13). Eventually, all of these notes will live elsewhere, like source code comments of github issues, but for now they are centralized in this document.
+
 ## Missing test coverage
 
 * elm-format tests unicode in string literals, but unicode can appear in variable names and possibly other places. We need to figure exactly where and how unicode can appear and add test coverage for that.
 
 * Should elm-format gracefully handle invalid utf-8? If so we might want test coverage for that.
+
+    **UPDATE:** It's really uncomon for people to have invalid utf-8, and if so, they proably have bigger probles than elm-format crashing. For now, just crashig with a descriptive error message is enoug.
 
 ## Notes on timeline
 

--- a/notes.md
+++ b/notes.md
@@ -57,9 +57,7 @@ All this said, I think we can start to think about what we want to do with our t
         The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. parsec however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 
 * `Text.Parsec.Char`
-    The functions in this module all deal with `Char` (AKA unicode). There's really only two important functions here: `satisfy` wich consumes chars as long as a predicate holds, and `string` which succeed if a given string exatcly matches what is being consumed, and fails otherwise.
-
-    Some care has to be taken here because parsec deals with `Char`'s whereas the new parser deals with `Word8`'s. The current implementation handles valid utf-8, but not invalid utf-8.
+    The functions in this module all deal with `Char` (AKA unicode). There's really only two important functions here: `satisfy` wich consumes chars as long as a predicate holds, and `string` which succeed if a given string exatcly matches what is being consumed, and fails otherwise.  Some care has to be taken here because parsec deals with `Char`'s whereas the new parser deals with `Word8`'s. The current implementation handles valid utf-8, but not invalid utf-8.
 
 * `Text.Parsec.Indent`
     * `indented`. Simple function.

--- a/notes.md
+++ b/notes.md
@@ -35,6 +35,8 @@ All this said, I think we can start to think about what we want to do with our t
 
         Difference being that `runParserT` converts the `String` to a `ByteString` first. Care has been taken that unicode points arent truncated when converting to `[Word8]` as an intermediate conversion step.
 
+    * `getPosition`, `getState`, `updateState`. Trivial implementations.
+
 * `Text.Parsec.Combinator`
     * `choice`. Implemented exactly as it was by parsec.
 

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,11 @@
 # GSOC Notes
 
+## Notes on functions
+
+    * Text.Parsec.Combinator.option
+
+        Implemented exatly as it was by parsec
+
 ## Mapping between the parsec and Elm parser
 
 `parsec` and `elm/compiler`'s parser very much operate on the same principles; continuation-passing style with four continuations in a parser: _empty ok_, _consumed ok_, _empty error_ and consumed error. `elm/compiler`'s parser if however less generic, it only parses bytestrings and has no concept of an "user" state. But `elm/compiler`s parser is general over the error type though, whereas `parsec` limits the user to string error messages

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,13 @@
 # GSOC Notes
 
+## Notes on timeline
+
+As the timeline stands now, most of the time will be spent implementing the wrapper functions. After some more work, I don't think that this is how it will play out, I think we can be more ambitious.
+
+Turns out there isn't as much to implement for the adapter layer as it might seem. `Text.Parsec.Char` only really consists of two major functions to implement, `string` and `satisfy`, all the other functions are implemented in terms of `satisfy`. Functions in `Text.Parsec.Combinator` are all implemented in terms of `Text.Parsec.Prim` functions. `Text.Parsec.Pos` and `Text.Parsec.Error` will essentially be copies of their respective parsec modules with minor changes. `Text.Parsec.Indent` probably won't do much either. So that leaves us with `Text.Parsec.Prim` containing the functions that need genuine implementations, apart from the _get*_, _set*_ and _update*_ style functions. This all leaves is with very few time consuming functions to implement. The one thing that has the potential of consuming a lot of time is if these foundational functions turns out to be very tricky to get right, with failing integration tests that could be to broad to help us pinpoint the bugs. Getting the first integration test to pass feels like to most difficult thing to do right now.
+
+All this said, I think we can start to think about what we want to do with our time after the adapter layer has been implemented.
+
 ## Notes on implemented functions
 
 * `Text.Parsec.Prim`
@@ -44,6 +52,8 @@
     * `string`. Risk of bugs, some undefined behavior.
 
         `string` is one of the more complex functions with recursion. Handling of carrige return and tabs is undefined (see comments in `Text.Parsec.Char.updatePos` for more info). This might have to be implemented at one point, or it might not be needed, so let's wait and see.
+
+        __EDIT:__ After doing some work on implementing `Text.Parsec.Char.satisfy` I've reallised that implementing `string` and `satisfy` might have some tricky behaviour relating unicode characters. Parsec operates on the character level whereas the new parser operates on a `Word8` level. With the naive behaviour that is implemented right now: if `string` encounters a `0x0a` which represents a newline in ASCII the parsers row is incremented, as it should when moving to the next line. But is it possible that there exists a unicode character that contains a `0x0a` byte as well? In that case that character will trigger the newline behaviour which would be a really subtle and devestating bug. Also, the column in parsec therefore represents unicode characters whereas the new parsers column represents bytes. Will the adapter layer have to convert that? It could be quite tricky in that case.
 
 ## Mapping between the parsec and Elm parser
 

--- a/notes.md
+++ b/notes.md
@@ -3,11 +3,29 @@
 ## Notes on implemented functions
 
 * `Text.Parsec.Prim`
+    * `Functor`, `Applicative` and `Monad` instances for `Parser`. Uses the underlying elm parser.
+
+        The implementations simply unwrap to the underlying `elm/compiler` parser, applies the relevant function and re-wraps. So for this to work `parsec` and `elm/compiler` need to have the same idea of how these instances should behave, which they seem to do from looking at the code.
+
+    * instance `Applicative.Alternative` for `Parser`. Implemented exactly as it was by parsec.
+
+    * instance `MonadPlus` for `Parser`. Risks of bugs being introduced. Implemented with dummy error handling
+
+        Is implemented using `Parse.Primitives.oneOf`. Pretty confident that it works as expected, except for the error handling which is undefined. Will have to look into if parsec merges errors, and if so, how.
+
+    * `<|>`. Implemented exactly as it was by parsec.
+
     * `<?>`. Dummy implementation.
+
+    * `try`. Implemented exactly as it was by parsec.
 
     * `many`. Risk of bugs being introduced.
 
-        The implementation of `many` is more complex than the usual functions in parsec, and recursion is being used. Furthermore this implementation does not closely follow the original implementation.
+        The implementation of `many` is one of the more complex functions in parsec, and recursion is being used. Furthermore this implementation does not closely follow the original implementation.
+
+    * `runParserT`. Closely follows the implementation of `Parse.Primitives.fromByteString`
+
+        Difference being that `runParserT` converts the `String` to a `ByteString` first. Care has been taken that unicode points arent truncated when converting to `[Word8]` as an intermediate conversion step.
 
 * `Text.Parsec.Combinator`
     * `option`. Implemented exactly as it was by parsec.
@@ -16,7 +34,7 @@
 
     * `eof`. Dummy implementation.
 
-        The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. `parsec` however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
+        The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. parsec however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 
 ## Mapping between the parsec and Elm parser
 

--- a/notes.md
+++ b/notes.md
@@ -5,6 +5,10 @@
 * `Text.Parsec.Prim`
     * `<?>`. Dummy implementation.
 
+    * `many`. Risk of bugs being introduced.
+
+        The implementation of `many` is more complex than the usual functions in parsec, and recursion is being used. Furthermore this implementation does not closely follow the original implementation.
+
 * `Text.Parsec.Combinator`
     * `option`. Implemented exactly as it was by parsec.
 

--- a/notes.md
+++ b/notes.md
@@ -31,6 +31,8 @@ All this said, I think we can start to think about what we want to do with our t
 
     * `many`. Risk of bugs being introduced.
 
+    * `skipMany`. Not to complicated.
+
     * `lookAhead`. Trivial implementation.
 
         The implementation of `many` is one of the more complex functions in parsec, and recursion is being used. Furthermore this implementation does not closely follow the original implementation.

--- a/notes.md
+++ b/notes.md
@@ -19,6 +19,8 @@ All this said, I think we can start to think about what we want to do with our t
 
     * instance `MonadPlus` for `Parser`. Risks of bugs being introduced.
 
+    * instance `Fail.MonadFail` for `Parser`. Implementation closely matches that of parsec.
+
         The implementation of `mplus` is straightforward except for the error merging behaviour in parsec, where if the tow parsers fails the errors are merged somehow. Not confident that I've got this right..
 
     * `<|>`. Implemented exactly as it was by parsec.

--- a/notes.md
+++ b/notes.md
@@ -49,11 +49,9 @@ All this said, I think we can start to think about what we want to do with our t
         The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. parsec however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 
 * `Text.Parsec.Char`
-    * `string`. Risk of bugs, some undefined behavior.
+    The functions in this module all deal with `Char` (AKA unicode). There's really only two important functions here: `satisfy` wich consumes chars as long as a predicate holds, and `string` which succeed if a given string exatcly matches what is being consumed, and fails otherwise.
 
-        `string` is one of the more complex functions with recursion. Handling of carrige return and tabs is undefined (see comments in `Text.Parsec.Char.updatePos` for more info). This might have to be implemented at one point, or it might not be needed, so let's wait and see.
-
-        __EDIT:__ After doing some work on implementing `Text.Parsec.Char.satisfy` I've reallised that implementing `string` and `satisfy` might have some tricky behaviour relating unicode characters. Parsec operates on the character level whereas the new parser operates on a `Word8` level. With the naive behaviour that is implemented right now: if `string` encounters a `0x0a` which represents a newline in ASCII the parsers row is incremented, as it should when moving to the next line. But is it possible that there exists a unicode character that contains a `0x0a` byte as well? In that case that character will trigger the newline behaviour which would be a really subtle and devestating bug. Also, the column in parsec therefore represents unicode characters whereas the new parsers column represents bytes. Will the adapter layer have to convert that? It could be quite tricky in that case.
+    Difficulties arrise by the fact that the new parser deals with input in terms of `Word8`'s, and one unicode `Char` can be represented by multiple `Word8`'s, so decoding and encoding might have to take pace. Currently, the implementation does not handle this, and runtime errors are thrown if unicode is encountered. Let's wait and see how elm-format uses `string` and `satisfy` first, for example if `string` is only used to match keywords, then we wont have to handle unicode in a nice way.
 
 ## Mapping between the parsec and Elm parser
 

--- a/notes.md
+++ b/notes.md
@@ -46,6 +46,8 @@ All this said, I think we can start to think about what we want to do with our t
 
     * `option`. Implemented exactly as it was by parsec.
 
+    * `optionMaybe`. Implemented exactly as it was by parsec.
+
     * `notFollowedBy`. Implemented exactly as it was by parsec.
 
     * `eof`. Dummy implementation.

--- a/notes.md
+++ b/notes.md
@@ -17,9 +17,9 @@ All this said, I think we can start to think about what we want to do with our t
 
     * instance `Applicative.Alternative` for `Parser`. Implemented exactly as it was by parsec.
 
-    * instance `MonadPlus` for `Parser`. Risks of bugs being introduced. Implemented with dummy error handling
+    * instance `MonadPlus` for `Parser`. Risks of bugs being introduced.
 
-        Is implemented using `Parse.Primitives.oneOf`. Pretty confident that it works as expected, except for the error handling which is undefined. Will have to look into if parsec merges errors, and if so, how.
+        The implementation of `mplus` is straightforward except for the error merging behaviour in parsec, where if the tow parsers fails the errors are merged somehow. Not confident that I've got this right..
 
     * `<|>`. Implemented exactly as it was by parsec.
 

--- a/notes.md
+++ b/notes.md
@@ -62,6 +62,10 @@ All this said, I think we can start to think about what we want to do with our t
     Difficulties arrise by the fact that the new parser deals with input in terms of `Word8`'s, and one unicode `Char` can be represented by multiple `Word8`'s, so decoding and encoding might have to take pace. Currently, the implementation does not handle this, and runtime errors are thrown if unicode is encountered. Let's wait and see how elm-format uses `string` and `satisfy` first, for example if `string` is only used to match keywords, then we wont have to handle unicode in a nice way.
 
 * `Text.Parsec.Indent`
+    * `indented`. Simple function.
+
+        In indents `indented` function there is a `put $ setSourceLine s (sourceLine pos)` line which I don't really get. All of the functions from indents used by elm-format only care about the column of the reference, and not the row, so don't think this will be a problem.
+
     * `withPos`. Simple function, but I might have done in wrong..
 
         Also, what exactly does the `_indent` field represent? Does it represent indentation in terms of coulmns, or some multiple thereof? Should be easy enough to pinpont if there is an issure here anyhow.

--- a/notes.md
+++ b/notes.md
@@ -36,6 +36,11 @@
 
         The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. parsec however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 
+* `Text.Parsec.Char`
+    * `string`. Risk of bugs, some undefined behavior.
+
+        `string` is one of the more complex functions with recursion. Handling of carrige return and tabs is undefined (see comments in `Text.Parsec.Char.updatePos` for more info). This might have to be implemented at one point, or it might not be needed, so let's wait and see.
+
 ## Mapping between the parsec and Elm parser
 
 `parsec` and `elm/compiler`'s parser very much operate on the same principles; continuation-passing style with four continuations in a parser: _empty ok_, _consumed ok_, _empty error_ and consumed error. `elm/compiler`'s parser if however less generic, it only parses bytestrings and has no concept of an "user" state. But `elm/compiler`s parser is general over the error type though, whereas `parsec` limits the user to string error messages

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,11 @@
 # GSOC Notes
 
+## Missing test coverage
+
+* elm-format tests unicode in string literals, but unicode can appear in variable names and possibly other places. We need to figure exactly where and how unicode can appear and add test coverage for that.
+
+* Should elm-format gracefully handle invalid utf-8? If so we might want test coverage for that.
+
 ## Notes on timeline
 
 As the timeline stands now, most of the time will be spent implementing the wrapper functions. After some more work, I don't think that this is how it will play out, I think we can be more ambitious.

--- a/notes.md
+++ b/notes.md
@@ -28,6 +28,8 @@
         Difference being that `runParserT` converts the `String` to a `ByteString` first. Care has been taken that unicode points arent truncated when converting to `[Word8]` as an intermediate conversion step.
 
 * `Text.Parsec.Combinator`
+    * `choice`. Implemented exactly as it was by parsec.
+
     * `many1`. Implemented exactly as it was by parsec.
 
     * `option`. Implemented exactly as it was by parsec.

--- a/notes.md
+++ b/notes.md
@@ -53,7 +53,7 @@ All this said, I think we can start to think about what we want to do with our t
 * `Text.Parsec.Char`
     The functions in this module all deal with `Char` (AKA unicode). There's really only two important functions here: `satisfy` wich consumes chars as long as a predicate holds, and `string` which succeed if a given string exatcly matches what is being consumed, and fails otherwise.
 
-    Difficulties arrise by the fact that the new parser deals with input in terms of `Word8`'s, and one unicode `Char` can be represented by multiple `Word8`'s, so decoding and encoding might have to take pace. Currently, the implementation does not handle this, and runtime errors are thrown if unicode is encountered. Let's wait and see how elm-format uses `string` and `satisfy` first, for example if `string` is only used to match keywords, then we wont have to handle unicode in a nice way.
+    Some care has to be taken here because parsec deals with `Char`'s whereas the new parser deals with `Word8`'s. The current implementation handles valid utf-8, but not invalid utf-8.
 
 * `Text.Parsec.Indent`
     * `indented`. Simple function.

--- a/notes.md
+++ b/notes.md
@@ -42,15 +42,7 @@ All this said, I think we can start to think about what we want to do with our t
     * `getPosition`, `getState`, `updateState`. Trivial implementations.
 
 * `Text.Parsec.Combinator`
-    * `choice`. Implemented exactly as it was by parsec.
-
-    * `many1`. Implemented exactly as it was by parsec.
-
-    * `option`. Implemented exactly as it was by parsec.
-
-    * `optionMaybe`. Implemented exactly as it was by parsec.
-
-    * `notFollowedBy`. Implemented exactly as it was by parsec.
+    Almost all of the functions in this module are implemented in terms of functions found in `Text.Parsec.Prim`, and as such most of the functions are implemented exactly as they where by parserc (except for formatting changes). Only functions that somehow differ from the implementetion in parsec are listed.
 
     * `eof`. Dummy implementation.
 

--- a/notes.md
+++ b/notes.md
@@ -29,6 +29,8 @@ All this said, I think we can start to think about what we want to do with our t
 
     * `many`. Risk of bugs being introduced.
 
+    * `lookAhead`. Trivial implementation.
+
         The implementation of `many` is one of the more complex functions in parsec, and recursion is being used. Furthermore this implementation does not closely follow the original implementation.
 
     * `runParserT`. Closely follows the implementation of `Parse.Primitives.fromByteString`

--- a/notes.md
+++ b/notes.md
@@ -1,10 +1,12 @@
 # GSOC Notes
 
-## Notes on functions
+## Notes on implemented functions
 
-    * Text.Parsec.Combinator.option
+* `Text.Parsec.Prim`
+    * `<?>`. Not correctly implemented - is a NoOp
 
-        Implemented exatly as it was by parsec
+* `Text.Parsec.Combinator`
+    * `option`. Implemented exatly as it was by parsec
 
 ## Mapping between the parsec and Elm parser
 

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,88 @@
+# GSOC Notes
+
+## Mapping between the parsec and Elm parser
+
+`parsec` and `elm/compiler`'s parser very much operate on the same principles; continuation-passing style with four continuations in a parser: _empty ok_, _consumed ok_, _empty error_ and consumed error. `elm/compiler`'s parser if however less generic, it only parses bytestrings and has no concept of an "user" state. But `elm/compiler`s parser is general over the error type though, whereas `parsec` limits the user to string error messages
+
+Here is what the declarations for the two parsers look like:
+
+`parsec`. The type variables `s`, `u`, `m` and `a` represents _input data_, _user state_, _underlying monad_ and _output_ respectively.
+```haskell
+-- The general parsec type
+newtype ParsecT s u m a =
+  ParsecT (
+    forall b .
+      State s u
+      -> (a -> State s u -> ParseError -> m b) -- consumed ok
+      -> (a -> State s u -> ParseError -> m b) -- empty ok
+      -> (ParseError -> m b)                   -- consumed err
+      -> (ParseError -> m b)                   -- empty err
+      -> m b
+
+data State s u =
+  State {
+    stateInput :: s,
+    statePos   :: !SourcePos,
+    stateUser  :: !u
+  }
+
+data SourcePos = SourcePos SourceName Line Column
+
+type SourceName = String
+type Line = Int
+type Column = Int
+
+
+-- The specific instance of parsec parser used in elm-format
+type IParser a = ParsecT String UserState UnderlyingMonad a
+
+data UserState = UserState
+  { newline :: [Bool]
+  }
+
+type UnderlyingMonad = Control.Monad.State SourcePos
+```
+
+`elm/compiler`:
+```haskell
+-- Elm
+newtype Parser x a =
+  Parser (
+    forall b.
+      State
+      -> (a -> State -> b)                       -- consumed ok
+      -> (a -> State -> b)                       -- empty ok
+      -> (Row -> Col -> (Row -> Col -> x) -> b)  -- consumed err
+      -> (Row -> Col -> (Row -> Col -> x) -> b)  -- empty err
+      -> b
+  )
+
+
+data State =
+  State
+    { _src :: ForeignPtr Word8
+    , _pos :: !(Ptr Word8)
+    , _end :: !(Ptr Word8)
+    , _indent :: !Word16
+    , _row :: !Row
+    , _col :: !Col
+    }
+
+
+type Row = Word16
+type Col = Word16
+```
+
+### Mapping state
+
+### Input
+In `elm/compiler`'s parser, `_src`, `_pos` and `_end` are internals of the input bytestring to parse. For `IParser` the input is a `String`. Mapping between these datatypes is easy, all the is needed is for care to be taken that unicode data in `Char`'s isn't truncated when converting to `Word8` before creating a bytestring with `pack`.
+
+### Location
+mapping between `elm/compiler`'s `_row`&`_col` the `Line`&`Column` in `parsec`'s `statePos :: SourcePos` is trivial. However, the `SourcePos` also stores a `SourceName`. I doubt that this is every used by `elm-format`, but if it is then the wrapper layer can store that information instead.
+
+### Indentation
+`elm-format` uses `indents` for indentation aware parsing, which stores indentation information in the _underlying monad_, i.e. this bit `Control.Monad.State SourcePos`. `elm/compiler` stores indentation in `_indent`. The problem arises of how to map `Word16` to `SourcePos`.. Turns out that while `indents` does make use of both `Line` and `Column` in `SourcePos`, the functions actually used by `elm-format` only ever cares about `Column`, which is exactly what `_indent` maps to. So this works out as well!
+
+### User state
+The user state in `elm-format` is the `newline :: [Bool]` bit, and I don't understand what that means. Will have to ask Aaron that.

--- a/notes.md
+++ b/notes.md
@@ -55,6 +55,11 @@ All this said, I think we can start to think about what we want to do with our t
 
     Difficulties arrise by the fact that the new parser deals with input in terms of `Word8`'s, and one unicode `Char` can be represented by multiple `Word8`'s, so decoding and encoding might have to take pace. Currently, the implementation does not handle this, and runtime errors are thrown if unicode is encountered. Let's wait and see how elm-format uses `string` and `satisfy` first, for example if `string` is only used to match keywords, then we wont have to handle unicode in a nice way.
 
+* `Text.Parsec.Indent`
+    * `withPos`. Simple function, but I might have done in wrong..
+
+        Also, what exactly does the `_indent` field represent? Does it represent indentation in terms of coulmns, or some multiple thereof? Should be easy enough to pinpont if there is an issure here anyhow.
+
 ## Mapping between the parsec and Elm parser
 
 `parsec` and `elm/compiler`'s parser very much operate on the same principles; continuation-passing style with four continuations in a parser: _empty ok_, _consumed ok_, _empty error_ and consumed error. `elm/compiler`'s parser if however less generic, it only parses bytestrings and has no concept of an "user" state. But `elm/compiler`s parser is general over the error type though, whereas `parsec` limits the user to string error messages

--- a/notes.md
+++ b/notes.md
@@ -66,6 +66,8 @@ All this said, I think we can start to think about what we want to do with our t
 
         In indents `indented` function there is a `put $ setSourceLine s (sourceLine pos)` line which I don't really get. All of the functions from indents used by elm-format only care about the column of the reference, and not the row, so don't think this will be a problem.
 
+    * `checkIndent`. Simple function.
+
     * `withPos`. Simple function, but I might have done in wrong..
 
         Also, what exactly does the `_indent` field represent? Does it represent indentation in terms of coulmns, or some multiple thereof? Should be easy enough to pinpont if there is an issure here anyhow.

--- a/notes.md
+++ b/notes.md
@@ -12,6 +12,8 @@
 * `Text.Parsec.Combinator`
     * `option`. Implemented exactly as it was by parsec.
 
+    * `many1`. Implemented exactly as it was by parsec.
+
     * `eof`. Dummy implementation.
 
         The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. `parsec` however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.

--- a/notes.md
+++ b/notes.md
@@ -3,10 +3,14 @@
 ## Notes on implemented functions
 
 * `Text.Parsec.Prim`
-    * `<?>`. Not correctly implemented - is a NoOp
+    * `<?>`. Dummy implementation.
 
 * `Text.Parsec.Combinator`
-    * `option`. Implemented exatly as it was by parsec
+    * `option`. Implemented exactly as it was by parsec.
+
+    * `eof`. Dummy implementation.
+
+        The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. `parsec` however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 
 ## Mapping between the parsec and Elm parser
 

--- a/notes.md
+++ b/notes.md
@@ -28,9 +28,11 @@
         Difference being that `runParserT` converts the `String` to a `ByteString` first. Care has been taken that unicode points arent truncated when converting to `[Word8]` as an intermediate conversion step.
 
 * `Text.Parsec.Combinator`
+    * `many1`. Implemented exactly as it was by parsec.
+
     * `option`. Implemented exactly as it was by parsec.
 
-    * `many1`. Implemented exactly as it was by parsec.
+    * `notFollowedBy`. Implemented exactly as it was by parsec.
 
     * `eof`. Dummy implementation.
 


### PR DESCRIPTION
This is PR is the first step in an effort to integrate the parser from the Elm compiler into elm-format as part of a GSOC project ([project proposal](https://github.com/elm-tooling/gsoc-projects/issues/13)).

This PR removes the dependency on [parsec](https://hackage.haskell.org/package/parsec) and [indents](https://hackage.haskell.org/package/indents-0.3.3) which have been used by elm-format to parse Elm code. The API these libraries provided has been replaced with drop-in replacement modules (located in `Text.Parsec.*`) compatible with elm-format. These replacement modules are implemented in terms of the new Elm parser (located in `Parse.Primitives` and copied from the Elm compiler). `new-parser-2021-notes.md` in the project root goes into more detail on some specifics relating to this project.

~~The entire test suite passes.~~