### PR TITLE
Bugfixes and small improvments to the parsec adapter

### DIFF
--- a/elm-format-lib/src/Text/Parsec/Char.hs
+++ b/elm-format-lib/src/Text/Parsec/Char.hs
@@ -149,9 +149,8 @@ updatePos width c (EP.State src pos end indent row col sourceName newline) =
 
         -- The parsec behaviour for tabs is to increment to the nearest
         -- 8'th collumn. Shoud we do this as well?
-        -- Let's not implement this unless it turns out that elm-format
-        -- needs it.
-        '\t' -> error "Can't handle tabs"
+        -- Let's follow the parsec behaviour
+        '\t' -> (row, (col + 8 - ((col-1) `mod` 8)))
 
         _ -> (row, col + 1)
   in

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -12,7 +12,7 @@ module Text.Parsec.Combinator
   ) where
 
 import qualified Parse.Primitives as EP
-import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many, skipMany)
+import Text.Parsec.Prim (unexpected, Parser(..), (<|>), (<?>), try, many, skipMany)
 import Text.Parsec.Error (Message(UnExpect), newErrorMessage)
 import Text.Parsec.Char (anyChar)
 
@@ -77,11 +77,4 @@ between open close p =
 -- I think the solution is to remove the eof behaviour from the new parser,
 -- but we'll see
 eof :: Parser ()
-eof =
-  EP.Parser $ \s@(EP.State _ pos end _ row col sourceName _) cok eok cerr eerr ->
-    if pos == end then
-      eok () s
-    else
-      -- In the parsec implementation the error message is the character that was found.
-      -- This behaviour would require some extra logic, so here the we just give "token" as the message instead.
-      eerr row col $ newErrorMessage (UnExpect "token") sourceName
+eof = notFollowedBy anyToken <?> "end of input"

--- a/elm-format-lib/src/Text/Parsec/Combinator.hs
+++ b/elm-format-lib/src/Text/Parsec/Combinator.hs
@@ -14,6 +14,7 @@ module Text.Parsec.Combinator
 import qualified Parse.Primitives as EP
 import Text.Parsec.Prim (unexpected, Parser(..), (<|>), try, many, skipMany)
 import Text.Parsec.Error (Message(UnExpect), newErrorMessage)
+import Text.Parsec.Char (anyChar)
 
 import Control.Monad (mzero, liftM)
 
@@ -54,7 +55,7 @@ optionMaybe p = option Nothing (liftM Just p)
 
 
 anyToken :: Parser Char
-anyToken = undefined
+anyToken = anyChar
 
 
 notFollowedBy :: Show a => Parser a -> Parser ()

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -186,7 +186,7 @@ runParserT (EP.Parser p) (State newline) name source =
       (B.PS fptr offset length) = stringToByteString source
       !pos = plusPtr (unsafeForeignPtrToPtr fptr) offset
       !end = plusPtr pos length
-      !result = p (EP.State fptr pos end 0 1 1 name newline) toOk toOk toErr toErr
+      !result = p (EP.State fptr pos end 1 1 1 name newline) toOk toOk toErr toErr
     in
     do  touchForeignPtr fptr
         return result

--- a/elm-format-lib/src/Text/Parsec/Prim.hs
+++ b/elm-format-lib/src/Text/Parsec/Prim.hs
@@ -117,7 +117,13 @@ infix  0 <?>
 
 
 (<?>) :: Parser a -> String -> Parser a
-(<?>) p _ = p
+(<?>) (EP.Parser p) msg =
+  EP.Parser $ \s@(EP.State _ _ _ _ _ _ sn _) cok eok cerr eerr ->
+    let
+      eerr' row col _ =
+        eerr row col (Error.newErrorMessage (Error.Expect msg) sn)
+    in
+    p s cok eok cerr eerr'
 
 
 lookAhead :: Parser a -> Parser a

--- a/new-parser-2021-notes.md
+++ b/new-parser-2021-notes.md
@@ -33,11 +33,11 @@ All this said, I think we can start to think about what we want to do with our t
 
     * instance `Fail.MonadFail` for `Parser`. Implementation closely matches that of parsec.
 
-        The implementation of `mplus` is straightforward except for the error merging behaviour in parsec, where if the tow parsers fails the errors are merged somehow. Not confident that I've got this right..
+        The implementation of `mplus` is straightforward except for the error merging behaviour in parsec, where if the two parsers fails the errors are merged somehow. Not confident that I've got this right..
 
     * `<|>`. Implemented exactly as it was by parsec.
 
-    * `<?>`. Dummy implementation.
+    * `<?>`. Possibly incomplete implementation. Parsec does error handling differently to the new parser, so how it's a bit unclear to me how to properly implement this, but I think this implementation should be acceptable.
 
     * `try`. Implemented exactly as it was by parsec.
 
@@ -58,7 +58,10 @@ All this said, I think we can start to think about what we want to do with our t
 * `Text.Parsec.Combinator`
     Almost all of the functions in this module are implemented in terms of functions found in `Text.Parsec.Prim`, and as such most of the functions are implemented exactly as they where by parserc (except for formatting changes). Only functions that somehow differ from the implementetion in parsec are listed.
 
-    * `eof`. Not implemented the way parser does it. Implemented in a way that's more straightforward with the new parser. The error message is less descriptive.
+    * `anyToken`. Same as `Text.Parsec.Char.anyChar`
+        Due to the adapter not being generic over the input type these two functions behave the same.
+
+    * `eof`. Implemented exactly as it was by parsec
 
         The elm parser fails if all input isn't consumed, which makes sense in the context of compiling Elm. parsec however defaults to succeeding even if everyting isn't consumed, and that behaviour is changed by `eof`. So as of right now, `eof` becommes a NoOp, maybe `Parse.Primitives` will have to be changed to not fail on unconsumed input (for elm-format it can still make sense to not parse all input) at some point, but not right not.
 
@@ -73,8 +76,6 @@ All this said, I think we can start to think about what we want to do with our t
     * `checkIndent`. Simple function.
 
     * `withPos`. Simple function, but I might have done in wrong..
-
-        Also, what exactly does the `_indent` field represent? Does it represent indentation in terms of coulmns, or some multiple thereof? Should be easy enough to pinpont if there is an issure here anyhow.
 
 ## Mapping between the parsec and Elm parser
 


### PR DESCRIPTION
This PR fixes two bugs found in #740 and adds some other improvments.

The three important changes are:
* The initial indentation level is set to 1 instead of 0. Row and column numbering starts at 1 so initial indentation now matches that. (see 425321d)
* `Text.Parsec.Indent.withPos` restores to the previous indentation before calling a continuation. (see 26dc657)
* `Text.Parsec.Pos.updatePos` can now handle tabs. (see 06c17f3)

Some less important changes:
* `Text.Parsec.Combinator.eof` gets an implementation exactly matching the parsec implementation.
* `Text.Parsec.Combinator.anyToken` gets an implementation (`eof` needs it)
* `Text.Parsec.Prim.(<?>)` gets an actual implementation instead of just leaving the parser unchanged, although the implementation might not exactly match the parsec behaviour.

It looks to me like the test suite passes with these additional commits.