### PR TITLE
Add macos aarch64 build support to Shakefile system

### DIFF
--- a/Shakefiles/Dependencies.hs
+++ b/Shakefiles/Dependencies.hs
@@ -4,6 +4,7 @@ import Development.Shake
 import Development.Shake.Command
 import Development.Shake.FilePath
 import Development.Shake.Util
+import Shakefiles.Extra (addMacOSGhcOptionFFI)
 
 
 localBinDir :: String
@@ -12,7 +13,8 @@ localBinDir = "bin"
 
 cabalInstallExe :: String -> Action ()
 cabalInstallExe package =
-    cmd_ "cabal"
+    cmd_ "cabal" $
+        addMacOSGhcOptionFFI
         [ "v2-install"
         , package
         , "--installdir", localBinDir
@@ -41,7 +43,7 @@ rules = do
             , "cabal.project"
             , "cabal.project.freeze"
             ]
-        cmd_ "cabal" [ "v2-build", "--only-dependencies" ]
+        cmd_ "cabal" $ addMacOSGhcOptionFFI [ "v2-build", "--only-dependencies" ]
         writeFile' out ""
 
     "_build/cabal-test-dependencies.ok" %> \out -> do
@@ -50,7 +52,7 @@ rules = do
             , "cabal.project"
             , "cabal.project.freeze"
             ]
-        cmd_ "cabal" [ "v2-build", "--only-dependencies", "--enable-tests" ]
+        cmd_ "cabal" $ addMacOSGhcOptionFFI [ "v2-build", "--only-dependencies", "--enable-tests" ]
         writeFile' out ""
 
     shellcheck %> \out -> do

--- a/Shakefiles/Extra.hs
+++ b/Shakefiles/Extra.hs
@@ -1,7 +1,8 @@
-module Shakefiles.Extra (phonyPrefix, forEach) where
+module Shakefiles.Extra (phonyPrefix, forEach, addMacOSGhcOptionFFI) where
 
 import Development.Shake
 import Data.List (stripPrefix)
+import Shakefiles.Platform (platform, Platform(..))
 
 
 phonyPrefix :: String -> (String -> Action ()) -> Rules ()
@@ -15,3 +16,12 @@ phonyPrefix prefix action =
 forEach :: Monad m => [a] -> (a -> m ()) -> m ()
 forEach list f =
     mapM_ f list
+
+
+--ghc-option required because of https://gitlab.haskell.org/ghc/ghc/-/issues/20592
+addMacOSGhcOptionFFI :: [String] -> [String]
+addMacOSGhcOptionFFI options =
+    case platform of
+        Mac -> ["--ghc-option=-I/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/ffi"] ++ options
+        MacArm64 -> ["--ghc-option=-I/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/ffi"] ++ options
+        _ -> options

--- a/Shakefiles/Haskell.hs
+++ b/Shakefiles/Haskell.hs
@@ -35,16 +35,16 @@ cabalProject name sourceFiles sourcePatterns deps testPatterns testDeps =
     do
         "_build/cabal/" </> name </> "build.ok" %> \out -> do
             hash <- needProjectFiles
-            cmd_ "cabal" "v2-build" "-O0"  (name ++ ":libs") "--enable-tests"
+            cmd_ "cabal" $ addMacOSGhcOptionFFI ["v2-build", "-O0", (name ++ ":libs"), "--enable-tests"]
             writeFile' out hash
 
         cabalBinPath name "noopt" %> \out -> do
             _ <- needProjectFiles
-            cmd_ "cabal" "v2-build" "-O0" (name ++ ":exes") "--enable-tests"
+            cmd_ "cabal" $ addMacOSGhcOptionFFI ["v2-build", "-O0", (name ++ ":exes"), "--enable-tests"]
 
         cabalBinPath name "opt" %> \out -> do
             _ <- needProjectFiles
-            cmd_ "cabal" "v2-build" "-O2" (name ++ ":exes")
+            cmd_ "cabal" $ addMacOSGhcOptionFFI ["v2-build", "-O2", (name ++ ":exes")]
 
         "_build/cabal/" </> name </> "test.ok" %> \out -> do
             need globalConfig
@@ -55,7 +55,7 @@ cabalProject name sourceFiles sourcePatterns deps testPatterns testDeps =
             need sourceFilesFromPatterns
             testFiles <- getDirectoryFiles "" testPatterns
             need testFiles
-            cmd_ "cabal" "v2-test" "-O0" (name ++ ":tests") "--test-show-details=streaming"
+            cmd_ "cabal" $ addMacOSGhcOptionFFI ["v2-test", "-O0", (name ++ ":tests"), "--test-show-details=streaming"]
             writeFile' out ""
 
 

--- a/Shakefiles/Platform.hs
+++ b/Shakefiles/Platform.hs
@@ -3,11 +3,12 @@ module Shakefiles.Platform (Platform(..), Shakefiles.Platform.all, platform, zip
 import qualified System.Info
 
 
-data Platform = Linux | Mac | Windows
+data Platform = Linux | Mac | MacArm64 | Windows
 
 instance Show Platform where
     show Linux = "linux-x64"
     show Mac = "mac-x64"
+    show MacArm64 = "mac-arm64"
     show Windows = "win-x64"
 
 
@@ -15,6 +16,7 @@ all :: [Platform]
 all =
     [ Linux
     , Mac
+    , MacArm64
     , Windows
     ]
 
@@ -24,6 +26,7 @@ platform =
     case (System.Info.os, System.Info.arch) of
         ("linux", "x86_64") -> Linux
         ("darwin", "x86_64") -> Mac
+        ("darwin", "aarch64") -> MacArm64
         ("osx", "x86_64") -> Mac
         ("mingw32", "x86_64") -> Windows
         ("win32", "x86_64") -> Windows
@@ -34,6 +37,7 @@ zipFormatFor :: Platform -> String
 zipFormatFor = \case
     Linux -> "tgz"
     Mac -> "tgz"
+    MacArm64 -> "tgz"
     Windows -> "zip"
 
 
@@ -41,6 +45,7 @@ binExt :: Platform -> String
 binExt = \case
     Linux -> ""
     Mac -> ""
+    MacArm64 -> ""
     Windows -> ".exe"
 
 
@@ -49,6 +54,7 @@ githubRunnerOs = \case
     Linux -> "Linux"
     Windows -> "Windows"
     Mac -> "macOS"
+    MacArm64 -> "macOS"
 
 
 cabalInstallOs :: String

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,12 @@ mkdir -p _build
 # install shake if it's not installed
 if ! grep -qs '^package-id \(shake\|shk\)-' "$PKG_ENV_FILE"; then
   echo "$0: installing shake"
-  cabal v2-install --package-env "$PKG_ENV_FILE" --lib shake
+  if [[ $OSTYPE == darwin* ]]; then
+    # --ghc-option required because of https://gitlab.haskell.org/ghc/ghc/-/issues/20592
+    cabal v2-install --package-env "$PKG_ENV_FILE" --ghc-option="`pkg-config --cflags libffi`" --lib shake
+  else
+    cabal v2-install --package-env "$PKG_ENV_FILE" --lib shake
+  fi
 fi
 
 # compile the build script


### PR DESCRIPTION
As mentioned on Discord, here are the rough changes I made last weekend to generate an aarch64 build on my M1 Mac using `./build.sh --verbose --verbose -- dist`.

Feels a little hacky, so happy to take feedback and refine :) 