### PR TITLE
Allow use of "infix" everywhere Elm 0.19 allows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 New features:
   - `case ... then` is now auto-corrected to `case ... of`
 
+Bug fixes:
+  - Top-level declarations named "infix" no longer make files unprocessable
+
 
 ## 0.8.6
 

--- a/elm-format-lib/src/Parse/Declaration.hs
+++ b/elm-format-lib/src/Parse/Declaration.hs
@@ -18,7 +18,7 @@ import Reporting.Annotation (Located)
 
 declaration :: ElmVersion -> IParser (ASTNS Located [UppercaseIdentifier] 'TopLevelDeclarationNK)
 declaration elmVersion =
-    typeDecl elmVersion <|> infixDecl elmVersion <|> port elmVersion <|> definition elmVersion
+    typeDecl elmVersion <|> try (infixDecl elmVersion) <|> port elmVersion <|> definition elmVersion
 
 
 topLevelStructure :: IParser a -> IParser (TopLevelStructure a)

--- a/tests/test-files/good/Elm-0.19/InfixAsVariableName.elm
+++ b/tests/test-files/good/Elm-0.19/InfixAsVariableName.elm
@@ -1,0 +1,27 @@
+module InfixAsVariableName exposing (..)
+
+{-| Despite being a keyword, "infix" is not a _reserved word_ in Elm 0.19,
+and is allowed as a variable name in expressions, type, and patterns.
+-}
+
+
+inExpression infix =
+    infix + 1
+
+
+type InType infix
+    = A infix
+
+
+{-| As top-level declaration
+-}
+infix x =
+    ()
+
+
+inLetDeclaration =
+    let
+        infix y =
+            ()
+    in
+    infix


### PR DESCRIPTION
Fixes https://github.com/avh4/elm-format/issues/728

- [x] check there is test coverage for uses of the `infix` keyword
  - [x] Elm 0.17
  - [x] Elm 0.18
  - [x] Elm 0.19
- [x] add new test case
- [x] implement fix 