### PR TITLE
Transform `=>` into `->` (lenient-parser) 🏹

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 New features:
   - `case ... then` is now auto-corrected to `case ... of`
+  - `=>` is now auto-corrected to `->`
 
 Bug fixes:
   - Top-level declarations named "infix" no longer make files unprocessable

--- a/tests/test-files/transform/Elm-0.19/TransformFatArrow.elm
+++ b/tests/test-files/transform/Elm-0.19/TransformFatArrow.elm
@@ -1,0 +1,2 @@
+foo : Int => Int => Int => Int
+foo = \a b c => a + b + c

--- a/tests/test-files/transform/Elm-0.19/TransformFatArrow.formatted.elm
+++ b/tests/test-files/transform/Elm-0.19/TransformFatArrow.formatted.elm
@@ -1,0 +1,5 @@
+module Main exposing (foo)
+
+
+foo : Int -> Int -> Int -> Int
+foo = \a b c -> a + b + c


### PR DESCRIPTION
[Apparently](https://twitter.com/Pilatch/status/1635624602855407616?s=20) some JS/Elm developers hit this case frequently, so it was worth a shot (let me know if you do not consider this contribution useful 🙏🏻 ).

Also sorry for a little noise but I was mostly addressing hlint recommendations for refactor/simplifications 😉 