### PR TITLE
Backfill test for using `=>` as an operator in Elm <= 0.18

### DIFF
--- a/tests/test-files/good/Elm-0.18/AllSyntax/Expressions/BinaryOperators.elm
+++ b/tests/test-files/good/Elm-0.18/AllSyntax/Expressions/BinaryOperators.elm
@@ -31,3 +31,14 @@ leftPipe a =
         a <|
             a <|
                 ()
+
+
+{-| elm-format will auto-correct `=>` to `->` when used in types and lambda introductions,
+but for Elm <= 0.18, it is valid as an expression and should be untouched in that usage.
+-}
+fatArrowOperator =
+    let
+        (=>) a b =
+            ()
+    in
+    1 => 2 => 3


### PR DESCRIPTION
As follow-up to https://github.com/avh4/elm-format/pull/809, this adds a test to ensure compatibility with Elm <= 0.18