### PR TITLE
Prepare 0.8.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## main
+## 0.8.7
 
 New features:
   - `case ... then` is now auto-corrected to `case ... of`
@@ -6,6 +6,7 @@ New features:
 
 Bug fixes:
   - Top-level declarations named "infix" no longer make files unprocessable
+  - The npm installer should now work correctly on Windows (was broken for 0.8.6)
 
 
 ## 0.8.6

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/avh4/elm-format.svg?branch=master)](https://travis-ci.org/avh4/elm-format)
-[![latest version: 0.8.6](https://img.shields.io/badge/version-0.8.6-orange.svg)](https://github.com/avh4/elm-format/releases/tag/0.8.6)
+[![latest version: 0.8.7](https://img.shields.io/badge/version-0.8.7-orange.svg)](https://github.com/avh4/elm-format/releases/tag/0.8.7)
 
 # elm-format
 
@@ -26,7 +26,7 @@ elm-format --help  # See other command line options
 ```
 
 
-## Installation [![(latest version: 0.8.6)](https://img.shields.io/badge/version-0.8.6-orange.svg)](https://github.com/avh4/elm-format/releases/tag/0.8.6)
+## Installation [![(latest version: 0.8.7)](https://img.shields.io/badge/version-0.8.7-orange.svg)](https://github.com/avh4/elm-format/releases/tag/0.8.7)
 
 To install `elm-format`:
 
@@ -34,7 +34,7 @@ To install `elm-format`:
 npm install -g elm-format
 ```
 
-or download the version appropriate for your OS from the [release page](https://github.com/avh4/elm-format/releases/tag/0.8.6),
+or download the version appropriate for your OS from the [release page](https://github.com/avh4/elm-format/releases/tag/0.8.7),
 unzip it,
 and place `elm-format` or `elm-format.exe` (windows) on your `PATH`.
 

--- a/Release Notes/0.8.7.md
+++ b/Release Notes/0.8.7.md
@@ -1,0 +1,31 @@
+## Small improvements and fixed npm installer for Windows
+
+Version 0.8.6 was not widely announced because of an issue with the npm installer on Windows,
+so check the [0.8.6 release notes](https://github.com/avh4/elm-format/releases/tag/0.8.6) as well.
+Below are the additional changes in 0.8.7.
+
+New features:
+  - `case ... then` is now auto-corrected to `case ... of`
+  - `=>` is now auto-corrected to `->`
+
+Bug fixes:
+  - Top-level declarations named "infix" no longer make files unprocessable
+  - The npm installer should now work correctly on Windows (was broken for 0.8.6)
+
+
+## Install
+
+```sh
+npm install -g elm-format
+```
+
+or [download from the release page](https://github.com/avh4/elm-format/releases/tag/0.8.7).
+
+
+## Thanks to ...
+
+  - @kutyel for lenient parsing additions
+  - @emmabastas for the initial draft of test coverage scripts
+  - @jfmengels for continued thoughtful issue discussion across the Elm devtools community (only partially related to elm-format, but thank you!)
+  - @8n8 for code cleanup help
+  - [Lamdera](https://www.lamdera.com/) for providing CI runners to build the MacOS ARM64 release binaries

--- a/Shakefile/src/Shakefiles/Haskell/Hpc.hs
+++ b/Shakefile/src/Shakefiles/Haskell/Hpc.hs
@@ -15,7 +15,7 @@ mergeTixFiles tixs out = do
 rules :: String -> Rules ()
 rules gitSha = do
     let hpcConfig =
-            [ "--hpcdir=./dist-newstyle/_coverage/build/x86_64-linux/ghc-9.2.5/elm-format-0.8.6/hpc/vanilla/mix/elm-format"
+            [ "--hpcdir=./dist-newstyle/_coverage/build/x86_64-linux/ghc-9.2.5/elm-format-0.8.7/hpc/vanilla/mix/elm-format"
             , "--hpcdir=./dist-newstyle/_coverage/build/x86_64-linux/ghc-9.2.5/avh4-lib-0.0.0.1/hpc/vanilla/mix/avh4-lib-0.0.0.1"
             , "--hpcdir=./dist-newstyle/_coverage/build/x86_64-linux/ghc-9.2.5/elm-format-lib-0.0.0.1/hpc/vanilla/mix/elm-format-lib-0.0.0.1"
             , "--hpcdir=./dist-newstyle/_coverage/build/x86_64-linux/ghc-9.2.5/elm-format-markdown-0.0.0.1/hpc/vanilla/mix/elm-format-markdown-0.0.0.1"

--- a/Style Guide/CI.md
+++ b/Style Guide/CI.md
@@ -38,7 +38,7 @@ A FormattingError will be an object with the following fields:
 ### Example JSON
 
 ```json
-[{"path":"./src/Fifo.elm","message":"File is not formatted with elm-format-0.8.6 --elm-version=0.19"}
-,{"path":"./tests/Tests.elm","message":"File is not formatted with elm-format-0.8.6 --elm-version=0.19"}
+[{"path":"./src/Fifo.elm","message":"File is not formatted with elm-format-0.8.7 --elm-version=0.19"}
+,{"path":"./tests/Tests.elm","message":"File is not formatted with elm-format-0.8.7 --elm-version=0.19"}
 ]
 ```

--- a/dev/Documentation/Publishing.md
+++ b/dev/Documentation/Publishing.md
@@ -80,7 +80,7 @@ cd package/nix
 ./build.sh
 ```
 
-Then `cd nixpkgs`, push the resulting branch, and make a PR to <https://github.com/NixOS/nixpkgs> with the title "`elm-format: <old version> -> <new version>`"
+Then `cd nixpkgs`, push the resulting branch, and make a PR to <https://github.com/NixOS/nixpkgs> with the title "`elmPackages.elm-format: <old version> -> <new version>`"
 
 
 ## Cleanup

--- a/elm-format.cabal
+++ b/elm-format.cabal
@@ -5,7 +5,7 @@ cabal-version: 2.2
 -- see: https://github.com/sol/hpack
 
 name:           elm-format
-version:        0.8.6
+version:        0.8.7
 synopsis:       A source code formatter for Elm
 description:    A simple way to format your Elm code according to the official
                 style guide.

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: elm-format
-version: 0.8.6
+version: 0.8.7
 
 synopsis: A source code formatter for Elm
 description: |

--- a/package/nix/build.sh
+++ b/package/nix/build.sh
@@ -8,17 +8,17 @@ ELM_FORMAT_VERSION="$(git describe --abbrev=8)"
 BRANCH="elm-format-$ELM_FORMAT_VERSION"
 
 if [ ! -d nixpkgs ]; then
-  git clone --branch master https://github.com/NixOS/nixpkgs.git nixpkgs
+  git clone --branch nixpkgs-unstable https://github.com/NixOS/nixpkgs.git nixpkgs
 fi
 
 pushd nixpkgs
-git fetch origin master
+git fetch origin nixpkgs-unstable
 git reset --hard
 if git branch | grep " ${BRANCH}$"; then
-  git checkout "$BRANCH"
-  git reset --hard origin/master
+  git switch "$BRANCH"
+  git reset --hard origin/nixpkgs-unstable
 else
-  git checkout -b "$BRANCH" origin/master
+  git switch -c "$BRANCH" origin/nixpkgs-unstable
   git reset --hard
 fi
 popd

--- a/package/nix/build.sh
+++ b/package/nix/build.sh
@@ -23,7 +23,9 @@ else
 fi
 popd
 
-cabal2nix --no-haddock https://github.com/avh4/elm-format --revision "$REV" --subpath avh4-lib > nixpkgs/pkgs/development/compilers/elm/packages/avh4-lib.nix
+cabal2nix --no-haddock --flag='--ghc-option=-Wno-error=unused-packages' https://github.com/avh4/elm-format --revision "$REV" --subpath avh4-lib \
+  | sed -e 's#-f--ghc-option=#--ghc-option=#;s#-wno-#-Wno-#' \
+  > nixpkgs/pkgs/development/compilers/elm/packages/avh4-lib.nix
 cabal2nix --no-haddock https://github.com/avh4/elm-format --revision "$REV" --subpath elm-format-lib > nixpkgs/pkgs/development/compilers/elm/packages/elm-format-lib.nix
 cabal2nix --no-haddock https://github.com/avh4/elm-format --revision "$REV" --subpath elm-format-test-lib > nixpkgs/pkgs/development/compilers/elm/packages/elm-format-test-lib.nix
 cabal2nix --no-haddock https://github.com/avh4/elm-format --revision "$REV" --subpath elm-format-markdown > nixpkgs/pkgs/development/compilers/elm/packages/elm-format-markdown.nix

--- a/package/npm/default.nix
+++ b/package/npm/default.nix
@@ -1,2 +1,2 @@
 {pkgs ? import <nixpkgs> {}}:
-import ./workspace.nix pkgs (import ./elm-format-0.8.6-windows.nix)
+import ./workspace.nix pkgs (import ./elm-format-0.8.7-rc.1.nix)

--- a/package/npm/default.nix
+++ b/package/npm/default.nix
@@ -1,2 +1,2 @@
 {pkgs ? import <nixpkgs> {}}:
-import ./workspace.nix pkgs (import ./elm-format-0.8.7-rc.1.nix)
+import ./workspace.nix pkgs (import ./elm-format-0.8.7.nix)

--- a/package/npm/elm-format-0.8.7-rc.1.nix
+++ b/package/npm/elm-format-0.8.7-rc.1.nix
@@ -1,0 +1,40 @@
+{
+  name = "elm-format";
+  version = "0.8.7";
+  prerelease = "rc.1";
+  binaryPackageScope = "avh4";
+  experimental = false;
+  elmVersions = [
+    "0.18.0"
+    "0.19.0"
+    "0.19.1"
+  ];
+
+  binaries = {
+    linux-x64 = {
+      v = "1";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7-rc.1/elm-format-0.8.7-rc.1-linux-x64.tgz";
+      sha256 = "sha256-yMD57UqAAh9NzVL+7eZNLscvD1qnJ8CG5EqrJ1i6z78=";
+    };
+    linux-aarch64 = {
+      v = "1";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7-rc.1/elm-format-0.8.7-rc.1-linux-aarch64.tgz";
+      sha256 = "sha256-fPEDXsK99vZbrf248f5uuEjzZK2a06GR34UBzw0WDvs=";
+    };
+    mac-x64 = {
+      v = "1";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7-rc.1/elm-format-0.8.7-rc.1-mac-x64.tgz";
+      sha256 = "sha256-itMJlqommJJzchcYwUnQpci5KPRcctfzm+DKyKBzsp0=";
+    };
+    mac-arm64 = {
+      v = "1";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7-rc.1/elm-format-0.8.7-rc.1-mac-arm64.tgz";
+      sha256 = "sha256-kdMTab6hR9mGN4pWoAztkhl4mflwO0K8U0BV+gbM7GM=";
+    };
+    win-x64 = {
+      v = "1";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7-rc.1/elm-format-0.8.7-rc.1-win-x64.zip";
+      sha256 = "sha256-VXmZ5CU7HJpihKT+M7kRup8S+f3MtXu4w5dfkQlzOyM=";
+    };
+  };
+}

--- a/package/npm/elm-format-0.8.7.nix
+++ b/package/npm/elm-format-0.8.7.nix
@@ -1,0 +1,40 @@
+{
+  name = "elm-format";
+  version = "0.8.7";
+  prerelease = null;
+  binaryPackageScope = "avh4";
+  experimental = false;
+  elmVersions = [
+    "0.18.0"
+    "0.19.0"
+    "0.19.1"
+  ];
+
+  binaries = {
+    linux-x64 = {
+      v = "2";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7/elm-format-0.8.7-linux-x64.tgz";
+      sha256 = "sha256-4iIRtg4j1DjlVG8q/VLrEKDnR2CuUR1iE0J/IVOj/G0=";
+    };
+    linux-aarch64 = {
+      v = "2";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7/elm-format-0.8.7-linux-aarch64.tgz";
+      sha256 = "sha256-jMvrk4AfyX/0Mzh/QZE605PZKnCLAYFVtmN4AprH+08=";
+    };
+    mac-x64 = {
+      v = "2";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7/elm-format-0.8.7-mac-x64.tgz";
+      sha256 = "sha256-2Fz2jVFeUUz+c0laE/IvJSlQdDDIibOwHu82r/oXAhA=";
+    };
+    mac-arm64 = {
+      v = "2";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7/elm-format-0.8.7-mac-arm64.tgz";
+      sha256 = "sha256-OqGWT5ybgon4xtFMpaz2MGtMSHTbHf7odhC3Ef9mh6E=";
+    };
+    win-x64 = {
+      v = "2";
+      url = "https://github.com/avh4/elm-format/releases/download/0.8.7/elm-format-0.8.7-win-x64.zip";
+      sha256 = "sha256-WZgJKDwGQhNcb8YvZn2AlmyxbtlHOdf3P22dv4ZdaxI=";
+    };
+  };
+}


### PR DESCRIPTION
# Official releases

- [x] publish binaries: https://github.com/avh4/elm-format/releases/tag/0.8.7
- [x] publish npm packages
- [x] elm-tooling `1.14.0` https://github.com/elm-tooling/elm-tooling-cli/pull/117
- [ ] nixpkgs: https://github.com/NixOS/nixpkgs/pull/225822

# Unofficial releases
- [ ] prettier-plugin-elm https://github.com/gicentre/prettier-plugin-elm/issues/45
- [x] homebrew https://github.com/Homebrew/homebrew-core/pull/128133
- [ ] AUR https://aur.archlinux.org/packages/elm-format-bin
- [ ] FreeBSD https://www.freshports.org/devel/elm-format