### PR TITLE
Fix arrow indentation in case patterns with comments

### DIFF
--- a/elm-format-lib/src/ElmFormat/Render/Box.hs
+++ b/elm-format-lib/src/ElmFormat/Render/Box.hs
@@ -1527,10 +1527,10 @@ formatExpression elmVersion importInfo aexpr =
                                    , indent body'
                                    ]
                         (_, _, pat', body') ->
-                            stack1 $
+                            stack1
                               [ pat'
-                              , line $ keyword "->"
-                              , indent body'
+                              , indent $ line $ keyword "->"
+                              , indent $ indent body'
                               ]
             in
                 (,) AmbiguousEnd $ -- TODO: not tested

--- a/tests/test-files/good/Elm-0.18/AllSyntax/Expressions.elm
+++ b/tests/test-files/good/Elm-0.18/AllSyntax/Expressions.elm
@@ -344,16 +344,16 @@ caseStatement =
                 {- O -}
                 Just x
                 {- P -}
-                ->
-                    {- Q -}
-                    x
+                    ->
+                        {- Q -}
+                        x
 
                 {- R -}
                 _
                 {- S -}
-                ->
-                    {- T -}
-                    2
+                    ->
+                        {- T -}
+                        2
 
         c =
             case
@@ -364,15 +364,15 @@ caseStatement =
                 --O
                 Just x
                 --P
-                ->
-                    --Q
-                    x
+                    ->
+                        --Q
+                        x
 
                 --R
                 _
                 --S
-                ->
-                    --T
-                    2
+                    ->
+                        --T
+                        2
     in
     {}

--- a/tests/test-files/good/Elm-0.19/AllSyntax/Expressions.elm
+++ b/tests/test-files/good/Elm-0.19/AllSyntax/Expressions.elm
@@ -351,16 +351,16 @@ caseStatement =
                 {- O -}
                 Just x
                 {- P -}
-                ->
-                    {- Q -}
-                    x
+                    ->
+                        {- Q -}
+                        x
 
                 {- R -}
                 _
                 {- S -}
-                ->
-                    {- T -}
-                    2
+                    ->
+                        {- T -}
+                        2
 
         c =
             case
@@ -371,15 +371,15 @@ caseStatement =
                 --O
                 Just x
                 --P
-                ->
-                    --Q
-                    x
+                    ->
+                        --Q
+                        x
 
                 --R
                 _
                 --S
-                ->
-                    --T
-                    2
+                    ->
+                        --T
+                        2
     in
     {}

--- a/tests/test-files/good/Elm-0.19/AllSyntax/Expressions.json
+++ b/tests/test-files/good/Elm-0.19/AllSyntax/Expressions.json
@@ -4653,11 +4653,11 @@
                                         "name": "x",
                                         "sourceLocation": {
                                             "end": {
-                                                "col": 22,
+                                                "col": 26,
                                                 "line": 356
                                             },
                                             "start": {
-                                                "col": 21,
+                                                "col": 25,
                                                 "line": 356
                                             }
                                         },
@@ -4699,7 +4699,7 @@
                                     },
                                     "sourceLocation": {
                                         "end": {
-                                            "col": 22,
+                                            "col": 26,
                                             "line": 356
                                         },
                                         "start": {
@@ -4715,11 +4715,11 @@
                                         },
                                         "sourceLocation": {
                                             "end": {
-                                                "col": 22,
+                                                "col": 26,
                                                 "line": 363
                                             },
                                             "start": {
-                                                "col": 21,
+                                                "col": 25,
                                                 "line": 363
                                             }
                                         },
@@ -4741,11 +4741,11 @@
                                     },
                                     "sourceLocation": {
                                         "end": {
-                                            "col": 22,
+                                            "col": 26,
                                             "line": 363
                                         },
                                         "start": {
-                                            "col": 22,
+                                            "col": 26,
                                             "line": 356
                                         }
                                     }
@@ -4753,7 +4753,7 @@
                             ],
                             "sourceLocation": {
                                 "end": {
-                                    "col": 22,
+                                    "col": 26,
                                     "line": 363
                                 },
                                 "start": {
@@ -4815,7 +4815,7 @@
                         "returnType": null,
                         "sourceLocation": {
                             "end": {
-                                "col": 22,
+                                "col": 26,
                                 "line": 363
                             },
                             "start": {
@@ -4833,11 +4833,11 @@
                                         "name": "x",
                                         "sourceLocation": {
                                             "end": {
-                                                "col": 22,
+                                                "col": 26,
                                                 "line": 376
                                             },
                                             "start": {
-                                                "col": 21,
+                                                "col": 25,
                                                 "line": 376
                                             }
                                         },
@@ -4879,7 +4879,7 @@
                                     },
                                     "sourceLocation": {
                                         "end": {
-                                            "col": 22,
+                                            "col": 26,
                                             "line": 376
                                         },
                                         "start": {
@@ -4895,11 +4895,11 @@
                                         },
                                         "sourceLocation": {
                                             "end": {
-                                                "col": 22,
+                                                "col": 26,
                                                 "line": 383
                                             },
                                             "start": {
-                                                "col": 21,
+                                                "col": 25,
                                                 "line": 383
                                             }
                                         },
@@ -4921,11 +4921,11 @@
                                     },
                                     "sourceLocation": {
                                         "end": {
-                                            "col": 22,
+                                            "col": 26,
                                             "line": 383
                                         },
                                         "start": {
-                                            "col": 22,
+                                            "col": 26,
                                             "line": 376
                                         }
                                     }
@@ -4933,7 +4933,7 @@
                             ],
                             "sourceLocation": {
                                 "end": {
-                                    "col": 22,
+                                    "col": 26,
                                     "line": 383
                                 },
                                 "start": {
@@ -4995,7 +4995,7 @@
                         "returnType": null,
                         "sourceLocation": {
                             "end": {
-                                "col": 22,
+                                "col": 26,
                                 "line": 383
                             },
                             "start": {


### PR DESCRIPTION
Fixes #824.

The example from the issue would be formatted as follows. Case A looks a little funky to me, but I couldn't find any existing examples of a multi-line pattern match with comments and associated data. The arrows stay in one column though, so that's good.

```elm
value =
    case x of
        -- A
        A
            -- B
            ()
            ->
                1

        -- C
        B
        -- D
            ->
                1
```