### PR TITLE
Relax upper bound on optparse-applicative

### DIFF
--- a/dev/build.sh
+++ b/dev/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 (cd Shakefile && hpack)

--- a/elm-format-lib/elm-format-lib.cabal
+++ b/elm-format-lib/elm-format-lib.cabal
@@ -98,7 +98,7 @@ library
     , containers >=0.6.5.1 && <0.7
     , elm-format-markdown
     , mtl >=2.2.2 && <3
-    , optparse-applicative >=0.17.0.0 && <0.19
+    , optparse-applicative >=0.17.0.0 && <0.20
     , relude >=1.1.0.0 && <1.3
     , text >=2.0 && <3
   default-language: Haskell2010
@@ -205,7 +205,7 @@ test-suite efl-tests
     , elm-format-test-lib
     , hspec >=2.7.4 && <3
     , mtl >=2.2.2 && <3
-    , optparse-applicative >=0.17.0.0 && <0.19
+    , optparse-applicative >=0.17.0.0 && <0.20
     , relude >=1.1.0.0 && <1.3
     , split >=0.2.3.4 && <0.3
     , tasty >=1.2 && <2

--- a/elm-format-lib/package.yaml
+++ b/elm-format-lib/package.yaml
@@ -34,7 +34,7 @@ dependencies:
   bytestring: ">= 0.11.3.0 && < 0.13"
   containers: ">= 0.6.5.1 && < 0.7"
   mtl: ">= 2.2.2 && < 3"
-  optparse-applicative: ">= 0.17.0.0 && < 0.19"
+  optparse-applicative: ">= 0.17.0.0 && < 0.20"
   relude: ">= 1.1.0.0 && < 1.3"
   text: ">= 2.0 && < 3"
   avh4-lib: {}

--- a/elm-format.cabal
+++ b/elm-format.cabal
@@ -52,7 +52,7 @@ executable elm-format
     , base >=4.15.0.0 && <5
     , bytestring >=0.11.3.0 && <0.13
     , elm-format-lib
-    , optparse-applicative >=0.17.0.0 && <0.19
+    , optparse-applicative >=0.17.0.0 && <0.12
     , relude >=1.1.0.0 && <1.3
     , text >=2.0 && <3
   default-language: Haskell2010
@@ -70,7 +70,6 @@ test-suite elm-format-tests
       ElmFormat.CliFlags
       ElmFormat.Messages
       ElmFormat.Version
-      Build_elm_format
       Paths_elm_format
   autogen-modules:
       Paths_elm_format
@@ -94,7 +93,7 @@ test-suite elm-format-tests
     , elm-format-lib
     , elm-format-test-lib
     , hspec >=2.7.4 && <3
-    , optparse-applicative >=0.17.0.0 && <0.19
+    , optparse-applicative >=0.17.0.0 && <0.12
     , quickcheck-io >=0.2.0 && <0.3
     , relude >=1.1.0.0 && <1.3
     , tasty >=1.2 && <2

--- a/elm-format.cabal
+++ b/elm-format.cabal
@@ -52,7 +52,7 @@ executable elm-format
     , base >=4.15.0.0 && <5
     , bytestring >=0.11.3.0 && <0.13
     , elm-format-lib
-    , optparse-applicative >=0.17.0.0 && <0.12
+    , optparse-applicative >=0.17.0.0 && <0.20
     , relude >=1.1.0.0 && <1.3
     , text >=2.0 && <3
   default-language: Haskell2010
@@ -93,7 +93,7 @@ test-suite elm-format-tests
     , elm-format-lib
     , elm-format-test-lib
     , hspec >=2.7.4 && <3
-    , optparse-applicative >=0.17.0.0 && <0.12
+    , optparse-applicative >=0.17.0.0 && <0.20
     , quickcheck-io >=0.2.0 && <0.3
     , relude >=1.1.0.0 && <1.3
     , tasty >=1.2 && <2

--- a/package.yaml
+++ b/package.yaml
@@ -39,7 +39,7 @@ dependencies:
   ansi-wl-pprint: ">= 0.6.9 && < 2.0"
   base: ">= 4.15.0.0 && < 5"
   bytestring: ">= 0.11.3.0 && < 0.13"
-  optparse-applicative: ">= 0.17.0.0 && < 0.19"
+  optparse-applicative: ">= 0.17.0.0 && < 0.12"
   relude: ">= 1.1.0.0 && < 1.3"
   text: ">= 2.0 && < 3"
   avh4-lib: {}


### PR DESCRIPTION
This simply relaxes upper bound on optparse-applicative. No additional changes needed. This makes it possible to build elm-format in more stackage snapshots and removes need for jailbreak in nixpkgs

https://github.com/NixOS/nixpkgs/pull/529072

As a side note - I would consider dropping hpack - it has many problems, is considered legacy and doesn't generate cabal files for this project correctly.